### PR TITLE
change dsp to tpz in Golden-Tongued_Culberry.lua

### DIFF
--- a/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
+++ b/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
@@ -15,9 +15,9 @@ function onMobFight(mob, target)
     mob:SetAutoAttackEnabled(false)
     mob:SetMobAbilityEnabled(false)
     if target:isPet() then
-        mob:setMod(dsp.mod.FASTCAST, 100)
+        mob:setMod(tpz.mod.FASTCAST, 100)
         mob:castSpell(367, target) -- Insta-death any pet with most enmity.
-        mob:setMod(dsp.mod.FASTCAST, 10)
+        mob:setMod(tpz.mod.FASTCAST, 10)
     end
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This was noticed and mentioned in Discord by Claywar and Geno.

This is the only reference to dsp table I see in topaz/scripts/
