### PR TITLE
[SQL] Fix drop on Nightmare cluster and Nightmare leech and change status to npc ???

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -9094,8 +9094,8 @@ INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,2668,10);
 INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,2673,10);
 INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,2719,10);
 INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,2724,10);
-INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3419,20); -- fiendish_tome_chapter_16
-INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3420,20); -- fiendish_tome_chapter_17
+INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3485,20); -- fiendish_tome_II_chapter_16
+INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3486,20); -- fiendish_tome_II_chapter_17
 INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3493,70); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (1786,0,0,1000,3494,70); -- forgotten_hope
 INSERT INTO `mob_droplist` VALUES (1787,2,0,1000,1449,0); -- (Nightmare_Crab Nightmare_Scorpion Nightmare_Dhalmel, Bu Lo)
@@ -9362,8 +9362,8 @@ INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,2668,10);
 INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,2673,10);
 INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,2719,10);
 INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,2724,10);
-INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3419,20); -- fiendish_tome_chapter_16
-INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3420,20); -- fiendish_tome_chapter_17
+INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3485,20); -- fiendish_tome_II_chapter_16
+INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3486,20); -- fiendish_tome_II_chapter_17
 INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3493,70); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (1796,0,0,1000,3494,70); -- forgotten_hope
 INSERT INTO `mob_droplist` VALUES (1797,2,0,1000,1452,0); -- (Nightmare_Makara, Ta)


### PR DESCRIPTION
Nightmare cluster and Nightmare leech dropped Fiendish Tome II (16) and (17) not Fiendish Tome I (16) and (17)

https://www.bg-wiki.com/bg/Nightmare_Cluster
https://www.bg-wiki.com/bg/Nightmare_Leech

**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

