### PR TITLE
[lua] remove last uses of GetMobAction from lua

### DIFF
--- a/scripts/zones/Dynamis-Xarcabard/IDs.lua
+++ b/scripts/zones/Dynamis-Xarcabard/IDs.lua
@@ -89,7 +89,9 @@ zones[tpz.zone.DYNAMIS_XARCABARD] =
                 {mob = 17330484, eye = dynamis.eye.BLUE },
             },
         },
+        DYNAMIS_LORD         = 17330177,
         YING                 = 17330183,
+        YANG                 = 17330184,
         COUNT_ZAEBOS_PH      = {[17330376] = 17330377}, -- Kindred_Warrior
         DUKE_GOMORY_PH       = {[17330303] = 17330304}, -- Kindred_Monk
         PRINCE_SEERE_PH      = {[17330331] = 17330332}, -- Kindred_White_Mage

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
@@ -2,6 +2,7 @@
 -- Area: Dynamis - Xarcabard
 --   NM: Yang
 -----------------------------------
+local ID = require("scripts/zones/Dynamis-Xarcabard/IDs")
 require("scripts/globals/status")
 -----------------------------------
 
@@ -9,7 +10,7 @@ function onMobInitialize(mob, target)
 end
 
 function onMobSpawn(mob)
-    local dynaLord = GetMobByID(17330177)
+    local dynaLord = GetMobByID(ID.mob.DYNAMIS_LORD)
     if (dynaLord:getLocalVar("physImmune") < 2) then -- both dragons have not been killed initially
         dynaLord:setMod(tpz.mod.UDMGPHYS, -100)
         dynaLord:setMod(tpz.mod.UDMGRANGE, -100)
@@ -21,12 +22,13 @@ function onMobSpawn(mob)
 end
 
 function onMobFight(mob, target)
-    local YingID = 17330183
-    local YingToD = mob:getLocalVar("YingToD")
     -- Repop Ying every 30 seconds if Yang is up and Ying is not.
-    if (GetMobAction(YingID) == tpz.act.NONE and os.time() > YingToD+30) then
-        GetMobByID(YingID):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
-        SpawnMob(YingID):updateEnmity(target)
+    local ying = GetMobByID(ID.mob.YING)
+    local YingToD = mob:getLocalVar("YingToD")
+    if ying:getCurrentAction() == tpz.act.NONE and os.time() > YingToD+30 then
+        ying:setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
+        ying:spawn()
+        ying:updateEnmity(target)
     end
 end
 
@@ -34,8 +36,8 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    local Ying = GetMobByID(17330183)
-    local dynaLord = GetMobByID(17330177)
+    local Ying = GetMobByID(ID.mob.YING)
+    local dynaLord = GetMobByID(ID.mob.DYNAMIS_LORD)
     -- localVars clear on death, so setting it on its partner
     Ying:setLocalVar("YangToD", os.time())
     if (dynaLord:getLocalVar("physImmune") == 0) then

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
@@ -2,6 +2,7 @@
 -- Area: Dynamis - Xarcabard
 --   NM: Ying
 -----------------------------------
+local ID = require("scripts/zones/Dynamis-Xarcabard/IDs")
 require("scripts/globals/status")
 -----------------------------------
 
@@ -9,7 +10,7 @@ function onMobInitialize(mob, target)
 end
 
 function onMobSpawn(mob)
-    local dynaLord = GetMobByID(17330177)
+    local dynaLord = GetMobByID(ID.mob.DYNAMIS_LORD)
     if (dynaLord:getLocalVar("magImmune") < 2) then -- both dragons have not been killed initially
         dynaLord:setMod(tpz.mod.UDMGMAGIC, -100)
         dynaLord:setMod(tpz.mod.UDMGBREATH, -100)
@@ -21,12 +22,13 @@ function onMobSpawn(mob)
 end
 
 function onMobFight(mob, target)
-    local YangID = 17330184
-    local YangToD = mob:getLocalVar("YangToD")
     -- Repop Yang every 30 seconds if Ying is up and Yang is not.
-    if (GetMobAction(YangID) == tpz.act.NONE and os.time() > YangToD+30) then
-        GetMobByID(YangID):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
-        SpawnMob(YangID):updateEnmity(target)
+    local yang = GetMobByID(ID.mob.YANG)
+    local YangToD = mob:getLocalVar("YangToD")
+    if yang:getCurrentAction() == tpz.act.NONE and os.time() > YangToD+30 then
+        yang:setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
+        yang:spawn()
+        yang:updateEnmity(target)
     end
 end
 
@@ -34,8 +36,8 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    local Yang = GetMobByID(17330184)
-    local dynaLord = GetMobByID(17330177)
+    local Yang = GetMobByID(ID.mob.YANG)
+    local dynaLord = GetMobByID(ID.mob.DYNAMIS_LORD)
     -- localVars clear on death, so setting it on its partner
     Yang:setLocalVar("YingToD", os.time())
     if (dynaLord:getLocalVar("magImmune") == 0) then


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* remove last uses of GetMobAction from lua
* add ID.mob references to DL, Ying, Yang

Note: the !getmobaction GM command does not use GetMobAction.  It uses targ:getCurrentAction().
