### PR TITLE
Fix: Revert stack handling changes in search server

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -114,12 +114,12 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
 
             PAHItem->ItemID = Sql_GetIntData(SqlHandle, 0);
 
-            PAHItem->SinglAmount = Sql_GetIntData(SqlHandle, 2);
+            PAHItem->SingleAmount = Sql_GetIntData(SqlHandle, 2);
             PAHItem->StackAmount = Sql_GetIntData(SqlHandle, 3);
 
             if (Sql_GetIntData(SqlHandle, 1) == 1)
             {
-                PAHItem->StackAmount = 0;
+                PAHItem->StackAmount = -1;
             }
 
             ItemList.push_back(PAHItem);

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -35,7 +35,7 @@ struct search_req;
 struct ahItem
 {
     uint16 ItemID;
-    uint32 SinglAmount;
+    uint32 SingleAmount;
     uint32 StackAmount;
 };
 

--- a/src/search/packets/auction_list.cpp
+++ b/src/search/packets/auction_list.cpp
@@ -55,7 +55,7 @@ CAHItemsListPacket::CAHItemsListPacket(uint16 offset)
 void CAHItemsListPacket::AddItem(ahItem* item)
 {
     ref<uint16>(m_PData, (0x18 + 0x0A * m_count) + 0) = item->ItemID;
-    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 2) = item->SinglAmount;
+    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 2) = item->SingleAmount;
     ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 6) = item->StackAmount;
 
     m_count++;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [ _ ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Reverts the thing that broke. Left a TODO to handle this properly in the future.