### PR TITLE
Fix: Trusts: Rollback various CMobEntity calls to CBattleEntity

### DIFF
--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -54,7 +54,7 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
 
 void CTrustEntity::PostTick()
 {
-    CMobEntity::PostTick();
+    CBattleEntity::PostTick();
     if (loc.zone && updatemask && status != STATUS_TYPE::DISAPPEAR)
     {
         loc.zone->PushPacket(this, CHAR_INRANGE, new CEntityUpdatePacket(this, ENTITY_UPDATE, updatemask));
@@ -69,7 +69,7 @@ void CTrustEntity::PostTick()
 
 void CTrustEntity::FadeOut()
 {
-    CMobEntity::FadeOut();
+    CBaseEntity::FadeOut();
     loc.zone->PushPacket(this, (loc.zone->m_BattlefieldHandler) ? CHAR_INZONE : CHAR_INRANGE, new CEntityUpdatePacket(this, ENTITY_DESPAWN, UPDATE_NONE));
 }
 
@@ -79,13 +79,13 @@ void CTrustEntity::Die()
     PAI->ClearStateStack();
     PAI->Internal_Die(0s);
     ((CCharEntity*)PMaster)->RemoveTrust(this);
-    CMobEntity::Die();
+    CBattleEntity::Die();
 }
 
 void CTrustEntity::Spawn()
 {
     // we need to skip CMobEntity's spawn because it calculates stats (and our stats are already calculated)
-    CMobEntity::Spawn();
+    CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
     ((CCharEntity*)PMaster)->pushPacket(new CTrustSyncPacket((CCharEntity*)PMaster, this));
 }
@@ -410,7 +410,7 @@ void CTrustEntity::OnDespawn(CDespawnState& /*unused*/)
 
 void CTrustEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
-    CMobEntity::OnCastFinished(state, action);
+    CBattleEntity::OnCastFinished(state, action);
 
     auto* PSpell = state.GetSpell();
 
@@ -424,7 +424,7 @@ void CTrustEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 
 void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
-    CMobEntity::OnWeaponSkillFinished(state, action);
+    CBattleEntity::OnWeaponSkillFinished(state, action);
 
     auto* PWeaponSkill  = state.GetSkill();
     auto* PBattleTarget = static_cast<CBattleEntity*>(state.GetTarget());


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Compared with the last known changes in old topaz, rolled back the base entity calls that were upgraded. Tested to see that things were sane.

Suspicion is that `clang-tidy` has done this...

