### PR TITLE
Correct Bracer Resell Price

### DIFF
--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -10023,7 +10023,7 @@ INSERT INTO `item_basic` VALUES (12718,0,'iron_mittens_+1','iron_mittens_+1',1,2
 INSERT INTO `item_basic` VALUES (12719,0,'mercenarys_tekko','mrc._tekko',1,2052,19,0,1368);
 INSERT INTO `item_basic` VALUES (12720,0,'gloves','gloves',1,2084,19,0,310);
 INSERT INTO `item_basic` VALUES (12721,0,'cotton_gloves','cotton_gloves',1,2084,19,0,372);
-INSERT INTO `item_basic` VALUES (12722,0,'bracers','bracers',1,2084,19,0,2464);
+INSERT INTO `item_basic` VALUES (12722,0,'bracers','bracers',1,2084,19,0,310);
 INSERT INTO `item_basic` VALUES (12723,0,'wool_bracers','wool_bracers',1,2084,19,0,3440);
 INSERT INTO `item_basic` VALUES (12724,0,'battle_bracers','battle_bracers',1,2084,19,0,4207);
 INSERT INTO `item_basic` VALUES (12725,0,'war_gloves','war_gloves',1,2084,19,0,6140);


### PR DESCRIPTION
Bracers were set to nearly 8x their retail NPC resell value, which is an issue being that players can purchase a crafting kit for 1600, less than the old 2464 resell value.

Retail resale price: 310 with no fame, 321 with max fame

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

