### PR TITLE
Two fixes for Snake Eye / Double-Up

### DIFF
--- a/scripts/globals/abilities/double-up.lua
+++ b/scripts/globals/abilities/double-up.lua
@@ -29,7 +29,7 @@ function onUseAbility(caster, target, ability, action)
         caster:setLocalVar("corsairActiveRoll", du_effect:getSubType())
         local snake_eye = caster:getStatusEffect(tpz.effect.SNAKE_EYE)
         if (snake_eye) then
-            if (prev_roll:getPower() > 5 and math.random(100) < snake_eye:getPower()) then
+            if (prev_roll:getPower() >= 5 and math.random(100) < snake_eye:getPower()) then
                 roll = 11
             else
                 roll = roll + 1

--- a/scripts/globals/abilities/snake_eye.lua
+++ b/scripts/globals/abilities/snake_eye.lua
@@ -14,7 +14,7 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
-    player:addStatusEffect(tpz.effect.SNAKE_EYE, (player:getMerit(tpz.merit.SNAKE_EYE) - 5), 0, 60)
+    player:addStatusEffect(tpz.effect.SNAKE_EYE, (player:getMerit(tpz.merit.SNAKE_EYE) - 10), 0, 60)
 
     return tpz.effect.SNAKE_EYE
 end

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -2,7 +2,7 @@
 --
 -- Host: localhost    Database: tpzdb
 -- ------------------------------------------------------
--- Server version	5.5.5-10.0.20-MariaDB
+-- Server version   5.5.5-10.0.20-MariaDB
 
 --
 -- Table structure for table `merits`
@@ -290,7 +290,7 @@ INSERT INTO `merits` VALUES (3008,'convergence',5,5,32768,7,46);
 INSERT INTO `merits` VALUES (3010,'diffusion',5,5,32768,7,46);
 INSERT INTO `merits` VALUES (3012,'enchainment',5,100,32768,7,46);
 INSERT INTO `merits` VALUES (3014,'assimilation',5,1,32768,7,46);
-INSERT INTO `merits` VALUES (3072,'snake_eye',5,5,65536,7,47);
+INSERT INTO `merits` VALUES (3072,'snake_eye',5,10,65536,7,47);
 INSERT INTO `merits` VALUES (3074,'fold',5,10,65536,7,47);
 INSERT INTO `merits` VALUES (3076,'winning_streak',5,20,65536,7,47);
 INSERT INTO `merits` VALUES (3078,'loaded_deck',5,10,65536,7,47);


### PR DESCRIPTION
this bonus is applied when current roll is 5+

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* When using Double-up, Snake Eye merits beyond the first grant a +10%/merit of hitting an 11. [fixes #2295]
* This bonus is applied when current roll is *5 or greater*, not *greater than 5*.
