### PR TITLE
[lua] fix reference to AnimationSub, speed bindings

### DIFF
--- a/scripts/globals/effects/bind.lua
+++ b/scripts/globals/effects/bind.lua
@@ -5,13 +5,13 @@
 -----------------------------------
 
 function onEffectGain(target, effect)
-    effect:setPower(target:speed())
-    target:speed(0)
+    effect:setPower(target:getSpeed())
+    target:setSpeed(0)
 end
 
 function onEffectTick(target, effect)
 end
 
 function onEffectLose(target, effect)
-    target:speed(effect:getPower())
+    target:setSpeed(effect:getPower())
 end

--- a/scripts/globals/mobskills/hex_palm.lua
+++ b/scripts/globals/mobskills/hex_palm.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (mob:getAnimationSub() == 1 or mob:AnimationSub() == 3) then
+    if (mob:getAnimationSub() == 1 or mob:getAnimationSub() == 3) then
         return 0
     else
         return 1

--- a/scripts/globals/spells/bind.lua
+++ b/scripts/globals/spells/bind.lua
@@ -27,7 +27,7 @@ function onSpellCast(caster, target, spell)
 
     if resist >= 0.5 then --Do it!
         --Try to erase a weaker bind.
-        if target:addStatusEffect(params.effect, target:speed(), 0 , duration * resist) then
+        if target:addStatusEffect(params.effect, target:getSpeed(), 0 , duration * resist) then
             spell:setMsg(tpz.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/bindga.lua
+++ b/scripts/globals/spells/bindga.lua
@@ -29,7 +29,7 @@ function onSpellCast(caster, target, spell)
 
     if (resist >= 0.5) then --Do it!
         --Try to erase a weaker bind.
-        if (target:addStatusEffect(tpz.effect.BIND, target:speed(), 0, duration*resist)) then
+        if (target:addStatusEffect(tpz.effect.BIND, target:getSpeed(), 0, duration*resist)) then
             spell:setMsg(tpz.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
@@ -15,7 +15,7 @@ function onMobRoamAction(mob)
     local prog = instance:getProgress()
 
     if (mob:isFollowingPath() == false) then
-        mob:speed(40)
+        mob:setSpeed(40)
         mob:pathThrough(ID.points[stage][prog].route, 9)
     end
 end

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -2,7 +2,7 @@
 -- Area: Balga's Dais
 --  Mob: Wyrm
 -- KSNM: Early Bird Catches the Wyrm
--- For future reference: Trusts are not allowed in this fight 
+-- For future reference: Trusts are not allowed in this fight
 -----------------------------------
 require("scripts/globals/status")
 
@@ -42,7 +42,7 @@ function onMobFight(mob, target)
     then
         mob:useMobAbility(954)
         -- Touchdown will set the following for us in the skill script:
-        -- lifted wings model stance: mob:AnimationSub(2)
+        -- lifted wings model stance: mob:setAnimationSub(2)
         -- reset default attack:      mob:SetMobSkillAttack(0)
         -- reset melee attacks:       mob:delStatusEffect(tpz.effect.TOO_HIGH)
         mob:addStatusEffect(tpz.effect.EVASION_BOOST, 75, 0, 0)

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
@@ -121,7 +121,7 @@ function onPath(mob)
 end
 
 function onMobSpawn(mob)
-    mob:speed(250)
+    mob:setSpeed(250)
     onPath(mob)
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

One AnimationSub reference that was missed by #2318 
A few speed references to go along with #2313
