### PR TITLE
[lua] fix some logIdTables being passed into quest/mission bindings

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -396,8 +396,20 @@ function npcUtil.completeQuest(player, area, quest, params)
         end
     end
 
+    local logId
+    if type(area) == "number" then
+        logId = area
+    elseif area["quest_log"] then
+        logId = area["quest_log"]
+    end
+
     -- successfully complete the quest
-    player:completeQuest(area, quest)
+    if logId then
+        player:completeQuest(logId, quest)
+    else
+        print("ERROR: invalid logId encountered in npcUtil.completeQuest")
+    end
+
     return true
 end
 

--- a/scripts/zones/Bastok_Markets/npcs/Gwill.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Gwill.lua
@@ -18,7 +18,7 @@ function onTrade(player, npc, trade)
         player:startEvent(243)
     end
 
-    if (player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_2") == 2) then
+    if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_2") == 2) then
         if (trade:hasItemQty(1127, 1) and trade:getItemCount() == 1) then -- Trade Kindred seal
             player:setCharVar("ridingOnTheClouds_2", 0)
             player:tradeComplete()

--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -18,7 +18,7 @@ function onTrade(player, npc, trade)
         if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
             player:startEvent(200) -- Finish quest "Collect Tarut Cards"
         end
-    elseif player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then
+    elseif player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then
         if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
             player:startEvent(10114) -- Finish quest "All in the Cards"
         end

--- a/scripts/zones/Lower_Jeuno/npcs/Garnev.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Garnev.lua
@@ -19,7 +19,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.A_CLOCK_MOST_DELICATE) == QUEST_ACCEPTED and player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.DEAL_WITH_TENSHODO) == QUEST_AVAILABLE) then
+    if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.A_CLOCK_MOST_DELICATE) == QUEST_ACCEPTED and player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.DEAL_WITH_TENSHODO) == QUEST_AVAILABLE) then
         if (player:getFameLevel(NORG) >= 2) then
             player:startEvent(167) -- Start quest
         else

--- a/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
@@ -18,7 +18,7 @@ function onTrigger(player, npc)
 
     local ANewDawn = player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.A_NEW_DAWN)
     local ANewDawnEvent = player:getCharVar("ANewDawn_Event")
-    local ScatteredIntoShadow = player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.SCATTERED_INTO_SHADOW)
+    local ScatteredIntoShadow = player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.SCATTERED_INTO_SHADOW)
 
     local SaveMySon = player:getCharVar("SaveMySon_Event")
 

--- a/scripts/zones/Metalworks/npcs/Iron_Eater.lua
+++ b/scripts/zones/Metalworks/npcs/Iron_Eater.lua
@@ -18,7 +18,7 @@ local TrustMemory = function(player)
     local memories = 0
     --[[ TODO
     -- 2 - The Three Kingdoms
-    if player:hasCompletedMission(tpz.mission.log_id.SANDORIA, tpz.mission.id.sandoria.JOURNEY_TO_BASTOK2) or player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) then
+    if player:hasCompletedMission(tpz.mission.log_id.SANDORIA, tpz.mission.id.sandoria.JOURNEY_TO_BASTOK2) or player:hasCompletedMission(tpz.mission.log_id.WINDURST, tpz.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) then
         memories = memories + 2
     end
     -- 4 - Where Two Paths Converge

--- a/scripts/zones/Mhaura/npcs/Rycharde.lua
+++ b/scripts/zones/Mhaura/npcs/Rycharde.lua
@@ -87,7 +87,7 @@ function onTrade(player, npc, trade)
             player:startEvent(93) -- that's not enogh!
         end
 
-    elseif (player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.THE_BASICS) == QUEST_ACCEPTED) then
+    elseif (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.THE_BASICS) == QUEST_ACCEPTED) then
         local BackedPototo  = trade:hasItemQty(4436, 1) --4436 - baked_popoto
         if (BackedPototo  == true) then
             player:startEvent(96)
@@ -144,7 +144,7 @@ elseif (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAr
     else
         player:startEvent(75) -- nothing to do
     end
-elseif (player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.HIS_NAME_IS_VALGEIR)==QUEST_ACCEPTED) then
+elseif (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.HIS_NAME_IS_VALGEIR)==QUEST_ACCEPTED) then
     if (player:hasKeyItem(tpz.ki.ARAGONEU_PIZZA)) then
         player:startEvent(87)-- forth quest   not done yet
     else

--- a/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
@@ -45,7 +45,7 @@ end
 
 function onTrigger(player, npc)
 
-    if (player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.THE_COMPETITION) == QUEST_AVAILABLE and player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_RIVALRY) == QUEST_AVAILABLE) then -- If you haven't started either quest yet
+    if (player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.THE_COMPETITION) == QUEST_AVAILABLE and player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.THE_RIVALRY) == QUEST_AVAILABLE) then -- If you haven't started either quest yet
         player:startEvent(300, 4401, 4289) -- 4401 = Moat Carp, 4289 = Forest Carp
     elseif (player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.THE_RIVALRY) == QUEST_ACCEPTED) then
         player:showText(npc, ID.text.GALLIJAUX_CARP_STATUS, 0, player:getCharVar("theCompetitionFishCountVar"))

--- a/scripts/zones/PsoXja/npcs/_i99.lua
+++ b/scripts/zones/PsoXja/npcs/_i99.lua
@@ -19,7 +19,7 @@ function onTrigger(player, npc)
         player:startEvent(109) -- Start Floor 1, 3 or 4
     elseif (player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.DESIRES_OF_EMPTINESS) or (player:getCurrentMission(COP) == tpz.mission.id.cop.DESIRES_OF_EMPTINESS and player:getCharVar("PromathiaStatus")==7)) then
         player:startEvent(112) -- Start Floor 1, 3, 4, or 5
-    elseif (player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR)or player:hasCompletedMission(COP, tpz.mission.id.cop.THE_LAST_VERSE)) then
+    elseif (player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR) or player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_LAST_VERSE)) then
         player:startEvent(50) -- Start Floor 1
     else
         player:messageSpecial(ID.text.DOOR_LOCKED)

--- a/scripts/zones/RuLude_Gardens/npcs/Adolie.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Adolie.lua
@@ -12,7 +12,7 @@ end
 
 function onTrigger(player, npc)
     local WildcatJeuno = player:getCharVar("WildcatJeuno")
-    if (player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatJeuno, 3)) then
+    if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatJeuno, 3)) then
         player:startEvent(10091)
     else
         player:startEvent(30) -- Standard dialog

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Rholont.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Rholont.lua
@@ -27,7 +27,7 @@ function onTrigger(player, npc)
     elseif (player:getCharVar("BoyAndTheBeast") > 1 and player:getQuestStatus(tpz.quest.log_id.CRYSTAL_WAR, tpz.quest.id.crystalWar.BOY_AND_THE_BEAST) ~= QUEST_COMPLETED) then
         player:startEvent(57)
 
-    elseif (player:getQuestStatus(vCRYSTAL_WAR, tpz.quest.id.crystalWar.BOY_AND_THE_BEAST) == QUEST_COMPLETED and player:getQuestStatus(tpz.quest.log_id.CRYSTAL_WAR, tpz.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) == QUEST_AVAILABLE) then
+    elseif (player:getQuestStatus(tpz.quest.log_id.CRYSTAL_WAR, tpz.quest.id.crystalWar.BOY_AND_THE_BEAST) == QUEST_COMPLETED and player:getQuestStatus(tpz.quest.log_id.CRYSTAL_WAR, tpz.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) == QUEST_AVAILABLE) then
         player:startEvent(59)
     elseif (player:getQuestStatus(tpz.quest.log_id.CRYSTAL_WAR, tpz.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) == QUEST_ACCEPTED) then
         if (player:getCharVar("WrathOfTheGriffon") < 2) then

--- a/scripts/zones/Tavnazian_Safehold/npcs/qm_unforgiven.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/qm_unforgiven.lua
@@ -9,12 +9,12 @@ require("scripts/globals/quests")
 require("scripts/globals/keyitems")
 -----------------------------------
 -- For those who don't know
--- at the end of if (player:getQuestStatus(REGION, QUEST_NAME)
+-- at the end of if (player:getQuestStatus(QUEST_LOG_ID, QUEST_NAME)
 -- == 0 means QUEST_AVAILABLE
 -- == 1 means QUEST_ACCEPTED
 -- == 2 means QUEST_COMPLETED
--- e.g. if (player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.UNFORGIVEN) == 0
--- means if (player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.UNFORGIVEN) == QUEST AVAILABLE
+-- e.g. if (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.UNFORGIVEN) == 0
+-- means if (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.UNFORGIVEN) == QUEST AVAILABLE
 
 function onTrade(player, npc, trade)
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Additional fixes to go along with Claywar's recent quest/mission bindings.

* Fix a few places where logId tables, rather than numbers, were being passed into quest or mission bindings
* npcUtil.completeQuest now picks quest_log off the table and passes it to the binding.  Or, if you give it the logId as a number, it passes that along.

edit: force-pushed to remove an unneeded require