### PR TITLE
[lua] convert more pairs/ipairs

### DIFF
--- a/scripts/globals/abilities/spirit_link.lua
+++ b/scripts/globals/abilities/spirit_link.lua
@@ -94,7 +94,7 @@ function onUseAbility(player, target, ability)
         local i = 0 -- highest existing index
         local copyi = 0
 
-        for _, effect in ipairs(effects) do
+        for _, effect in effects:pairs() do
             if bit.band(effect:getFlag(), tpz.effectFlag.EMPATHY) == tpz.effectFlag.EMPATHY then
                 validEffects[i+1] = effect
                 i = i + 1

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -729,7 +729,7 @@ end
 
 function checkForElevenRoll(caster)
     local effects = caster:getStatusEffects()
-    for _,effect in ipairs(effects) do
+    for _,effect in effects:pairs() do
         if (effect:getType() >= tpz.effect.FIGHTERS_ROLL and
             effect:getType() <= tpz.effect.NATURALISTS_ROLL and
             effect:getSubPower() == 11) then

--- a/scripts/globals/allyassist.lua
+++ b/scripts/globals/allyassist.lua
@@ -17,7 +17,7 @@ tpz.ally =
         local allies = {}
 
         if entity:getBattlefield() ~= nil then
-            mobs = entity:getBattlefield():getEnemies()
+            mobs = entity:getBattlefield():getMobs()
             players = entity:getBattlefield():getPlayers()
         elseif entity:getInstance() ~= nil then
             mobs = entity:getInstance():getMobs()
@@ -26,7 +26,7 @@ tpz.ally =
 
         -- print("start inserting mob")
         local targetMobs = {}
-        for i, mob in pairs(mobs) do
+        for i, mob in mobs:pairs() do
             if mob:isSpawned() and mob:isAlive() then
                 if mob:isAlly() then
                     table.insert(allies, mob)

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -89,7 +89,7 @@ function tpz.battlefield.onBattlefieldTick(battlefield, timeinside, players)
         end
     end
 
-    for _, mob in pairs(mobs) do
+    for _, mob in mobs:pairs() do
         if mob:isAlive() then
             killedallmobs = false
             break

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -115,7 +115,7 @@ local function timeElapsedCheck(npc)
     if npc:getLocalVar("[caskets]SPAWNTIME") then
         spawnTime = npc:getLocalVar("[caskets]SPAWNTIME")
     end
-    
+
     local lastSpawned = os.time() - spawnTime
 
     timeTable = convertTime(lastSpawned)
@@ -192,7 +192,7 @@ local function sendChestDropMessage(player)
 
     party = player:getAlliance()
 
-    for _, member in ipairs(party) do
+    for _, member in party:pairs() do
         if member:getZoneID() == player:getZoneID() then
             member:messageSpecial(dropMessage , 0)
         end

--- a/scripts/globals/items/joyous_serinette.lua
+++ b/scripts/globals/items/joyous_serinette.lua
@@ -10,7 +10,7 @@ end
 
 function onItemUse(target)
     local alliance = target:getAlliance()
-    for i, member in pairs(alliance) do
+    for i, member in alliance:pairs() do
         if member:getZoneID() == target:getZoneID() then
             member:ChangeMusic(0, 214) -- Eternal Oath
             member:ChangeMusic(1, 214) -- Eternal Oath

--- a/scripts/globals/items/serene_serinette.lua
+++ b/scripts/globals/items/serene_serinette.lua
@@ -10,7 +10,7 @@ end
 
 function onItemUse(target)
     local alliance = target:getAlliance()
-    for i, member in pairs(alliance) do
+    for i, member in alliance:pairs() do
         if member:getZoneID() == target:getZoneID() then
             member:ChangeMusic(0, 153) -- Prelude
             member:ChangeMusic(1, 153) -- Prelude

--- a/scripts/globals/mobskills/lunar_roar.lua
+++ b/scripts/globals/mobskills/lunar_roar.lua
@@ -17,7 +17,7 @@ function onMobWeaponSkill(target, mob, skill)
     local effects = target:getStatusEffects()
     local num = 0
 
-    for i, effect in ipairs(effects) do
+    for i, effect in effects:pairs() do
         -- check mask bit for tpz.effectFlag.DISPELABLE
         if (utils.mask.getBit(effect:getFlag(), 0) and effect:getType() ~= tpz.effect.RERAISE and num < 10) then
             target:delStatusEffect(effect:getType())

--- a/scripts/globals/mobskills/sand_pit.lua
+++ b/scripts/globals/mobskills/sand_pit.lua
@@ -47,7 +47,7 @@ function onMobWeaponSkill(target, mob, skill)
     elseif (PoolID == 4046) then
         -- Tuchulcha (Sheep in Antlion's Clothing)
         -- Resets all enmity
-        for _, enmAlly in pairs(mob:getBattlefield():getAllies()) do
+        for _, enmAlly in mob:getBattlefield():getAllies():pairs() do
             mob:resetEnmity(enmAlly)
         end
         -- Removes all enfeebling effects

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -45,7 +45,7 @@ function doHealingBreath(player, threshold, breath)
         player:getPet():useJobAbility(breath, player)
     else
         local party = player:getParty()
-        for _, member in ipairs(party) do
+        for _, member in party:pairs() do
             if member:getHPP() < threshold and inBreathRange(member) then
                 player:getPet():useJobAbility(breath, member)
                 break
@@ -91,7 +91,7 @@ function onMobSpawn(mob)
         master:addListener("WEAPONSKILL_USE", "PET_WYVERN_WS", function(player, target, skillid)
             if not doStatusBreath(player, player) then
                 local party = player:getParty()
-                for _, member in ipairs(party) do
+                for _, member in party:pairs() do
                     if doStatusBreath(member, player) then
                         break
                     end

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
@@ -82,7 +82,7 @@ function onEventUpdate(player, csid, option, target)
     if pathOfDarkness == 1 then
 
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() then
                     if v:getCurrentMission(TOAU) < tpz.mission.id.toau.PATH_OF_DARKNESS then
                         player:messageText(target, ID.text.MEMBER_NO_REQS, false)
@@ -101,7 +101,7 @@ function onEventUpdate(player, csid, option, target)
     elseif nashmeirasPlea == 1 then
 
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() then
                     if v:getCurrentMission(TOAU) < tpz.mission.id.toau.NASHMEIRAS_PLEA then
                         player:messageText(target, ID.text.MEMBER_NO_REQS, false)
@@ -120,7 +120,7 @@ function onEventUpdate(player, csid, option, target)
     else
 
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() then
                     if not v:hasKeyItem(tpz.ki.NYZUL_ISLE_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid then
                         player:messageText(target, ID.text.MEMBER_NO_REQS, false)
@@ -172,7 +172,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(116, 2)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20t.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20t.lua
@@ -33,7 +33,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if party ~= nil then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if not v:hasKeyItem(tpz.ki.REMNANTS_PERMIT) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -68,7 +68,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(116, 2)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
@@ -35,7 +35,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if party ~= nil then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if not v:hasKeyItem(tpz.ki.REMNANTS_PERMIT) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -70,7 +70,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(116, 8)

--- a/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
@@ -29,7 +29,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
     if player:getLocalVar("theblackcoffinfight") == 1 then
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if not v:hasKeyItem(tpz.ki.EPHRAMADIAN_GOLD_COIN) then
                     player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                     player:instanceEntry(target, 1)
@@ -47,7 +47,7 @@ function onEventUpdate(player, csid, option, target)
 
         elseif player:getLocalVar("againstalloddsfight") == 1 then
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getZoneID() == player:getZoneID() and v:checkDistance(player) > 50 then
                     player:messageText(target, ID.text.MEMBER_TOO_FAR, false)
                     player:instanceEntry(target, 1)
@@ -75,7 +75,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(90) -- wrong csid, yet better than nothing

--- a/scripts/zones/Arrapago_Reef/npcs/_jic.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jic.lua
@@ -46,7 +46,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if (party ~= nil) then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if (not (v:hasKeyItem(tpz.ki.ILRUSI_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid)) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -81,7 +81,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(108, 2)

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g2.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g2.lua
@@ -46,7 +46,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if (party ~= nil) then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if (not (v:hasKeyItem(tpz.ki.MAMOOL_JA_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid)) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -81,7 +81,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(108, 1)

--- a/scripts/zones/Caedarva_Mire/npcs/_272.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_272.lua
@@ -50,7 +50,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if (party ~= nil) then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if (not (v:hasKeyItem(tpz.ki.LEUJAOAM_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid)) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -85,7 +85,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(130, 0)

--- a/scripts/zones/Caedarva_Mire/npcs/_273.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_273.lua
@@ -50,7 +50,7 @@ function onEventUpdate(player, csid, option, target)
 
     if player:getCharVar("ShadesOfVengeance") == 1 then
         if (party ~= nil) then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getCurrentMission(TOAU) < tpz.mission.id.toau.SHADES_OF_VENGEANCE then
                     player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                     player:instanceEntry(target, 1)
@@ -65,7 +65,7 @@ function onEventUpdate(player, csid, option, target)
         player:createInstance(79, 56)
     else
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if (not (v:hasKeyItem(tpz.ki.PERIQIA_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid)) then
                     player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                     player:instanceEntry(target, 1)
@@ -100,7 +100,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if (v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID()) then
                     v:setInstance(instance)
                     v:startEvent(133)
@@ -118,7 +118,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party ~= nil then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(133, 3)

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -15,7 +15,7 @@ end
 
 function onMobEngaged(mob, target)
     local bcnmAllies = mob:getBattlefield():getAllies()
-    for i, v in pairs(bcnmAllies) do
+    for i, v in bcnmAllies:pairs() do
         if v:getName() == "Prishe" then
             if not v:getTarget() then
                 v:entityAnimationPacket("prov")
@@ -35,7 +35,7 @@ function onMobFight(mob, target)
     end
 
     local bcnmAllies = mob:getBattlefield():getAllies()
-    for i, v in pairs(bcnmAllies) do
+    for i, v in bcnmAllies:pairs() do
         if not v:getTarget() then
             v:addEnmity(mob, 0, 1)
         end
@@ -71,7 +71,7 @@ function onEventFinish(player, csid, option, target)
         DespawnMob(target:getID())
         mob = SpawnMob(target:getID()+1)
         local bcnmAllies = mob:getBattlefield():getAllies()
-        for i, v in pairs(bcnmAllies) do
+        for i, v in bcnmAllies:pairs() do
             v:resetLocalVars()
             local spawn = v:getSpawnPos()
             v:setPos(spawn.x, spawn.y, spawn.z, spawn.rot)

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -23,7 +23,7 @@ end
 
 function onMobEngaged(mob, target)
     local bcnmAllies = mob:getBattlefield():getAllies()
-    for i, v in pairs(bcnmAllies) do
+    for i, v in bcnmAllies:pairs() do
         if v:getName() == "Prishe" then
             if not v:getTarget() then
                 v:entityAnimationPacket("prov")
@@ -47,7 +47,7 @@ function onMobFight(mob, target)
     end
 
     local bcnmAllies = mob:getBattlefield():getAllies()
-    for i, v in pairs(bcnmAllies) do
+    for i, v in bcnmAllies:pairs() do
         if not v:getTarget() then
             v:addEnmity(mob, 0, 1)
         end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ajido-Marujido.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ajido-Marujido.lua
@@ -61,7 +61,7 @@ end
 
 function onMobDeath(mob, player, isKiller)
     mob:getBattlefield():lose()
-        for _, player in ipairs(mob:getBattlefield():getPlayers()) do
+        for _, player in mob:getBattlefield():getPlayers():pairs() do
             player:messageSpecial(ID.text.UNABLE_TO_PROTECT)
         end
 end

--- a/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
@@ -43,7 +43,7 @@ function onEventUpdate(player, csid, option, target)
     local party = player:getParty()
 
     if party then
-        for i, v in ipairs(party) do
+        for i, v in party:pairs() do
             if not (v:hasKeyItem(tpz.ki.LEBROS_ASSAULT_ORDERS) and v:getCurrentAssault() == assaultid) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)
                 player:instanceEntry(target, 1)
@@ -76,7 +76,7 @@ function onInstanceCreated(player, target, instance)
 
         local party = player:getParty()
         if party then
-            for i, v in ipairs(party) do
+            for i, v in party:pairs() do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
                     v:startEvent(208, 2)

--- a/scripts/zones/Nyzul_Isle/instances/path_of_darkness.lua
+++ b/scripts/zones/Nyzul_Isle/instances/path_of_darkness.lua
@@ -51,7 +51,7 @@ function onInstanceProgressUpdate(instance, progress)
 
         local npcs = instance:getNpcs()
 
-        for i, v in pairs(npcs) do
+        for i, v in npcs:pairs() do
             if(v:getID() == ID.npc._259) then
                 v:setAnimation(8)
             end

--- a/scripts/zones/Nyzul_Isle/mobs/Imperial_Gear.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Imperial_Gear.lua
@@ -13,7 +13,7 @@ function onMobSpawn(mob)
     if (progress >= 24) then
         local mobs = instance:getMobs()
 
-        for i, v in pairs(mobs) do
+        for i, v in mobs:pairs() do
             if (v:getID() == ID.mob[58].AMNAF_BLU) then
                 local pos = v:getPos()
 

--- a/scripts/zones/Qufim_Island/mobs/Ophiotaurus.lua
+++ b/scripts/zones/Qufim_Island/mobs/Ophiotaurus.lua
@@ -13,7 +13,7 @@ end
 
 function onMobDeath(mob, player, isKiller)
     local party = player:getParty()
-    for _, member in ipairs(party) do
+    for _, member in party:pairs() do
         if member:getCurrentMission(ROV) == tpz.mission.id.rov.THE_LIONS_ROAR then
             member:completeMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.THE_LIONS_ROAR)
             member:addMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.EDDIES_OF_DESPAIR_I)

--- a/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Crew.lua
+++ b/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Crew.lua
@@ -8,14 +8,14 @@ local ID = require("scripts/zones/The_Ashu_Talif/IDs")
 
 function onMobEngaged(mob, target)
     local allies = mob:getInstance():getAllies()
-    for i, v in pairs(allies) do
+    for i, v in allies:pairs() do
         if (v:isAlive()) then
             v:setLocalVar("ready", 1)
         end
     end
 
     local mobs = mob:getInstance():getMobs()
-    for i, v in pairs(mobs) do
+    for i, v in mobs:pairs() do
         if(v:isAlive()) then
             v:setLocalVar("ready", 1)
         end

--- a/scripts/zones/West_Ronfaure/npcs/Vilatroire.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Vilatroire.lua
@@ -67,7 +67,7 @@ function onEventUpdate(player, csid, option)
 
         if #party >= partySizeRequirement then
 
-            for key, member in pairs(party) do
+            for key, member in party:pairs() do
                 local mRace = member:getRace()
 
                 if member:getZoneID() ~= player:getZoneID() or member:checkDistance(player) > 15 then

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Siren.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Siren.lua
@@ -17,7 +17,7 @@ end
 
 function onMobDeath(mob, player, isKiller)
     local party = player:getParty()
-    for _, member in ipairs(party) do
+    for _, member in party:pairs() do
         if member:getCurrentMission(ROV) == tpz.mission.id.rov.THE_LOST_AVATAR then
             player:setCharVar("RhapsodiesStatus", 1)
         end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This PR goes along with #2327 and #2338.

* in allyAssist.lua, change getEnemies() to getMobs(). [fixes #2336]
* check lua files for all cases<sup>1</sup> of looping over a binding output with `pairs(result)` or `ipairs(result)`, and change to `result:pairs()`

<sup>1</sup>As far as I can tell, this covers all the bindings that we're looping over in LUA, with the exception of :getEnmityList().  Because baseEntity:getEnmityList() returns `sol::table` rather than `std::vector`, I did not convert to use `:pairs()` in this PR.