### PR TITLE
[lua] add missing textId for Imperial Whitegate

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
@@ -25,6 +25,7 @@ zones[tpz.zone.AHT_URHGAN_WHITEGATE] =
         HOMEPOINT_SET                 = 1371, -- Home point set!
         IMAGE_SUPPORT_ACTIVE          = 1410, -- You have to wait a bit longer before asking for synthesis image support again.
         IMAGE_SUPPORT                 = 1412, -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].
+        GATE_IS_FIRMLY_CLOSED         = 1429, -- The gate is firmly closed...
         REGIME_CANCELED               = 1471, -- Current training regime canceled.
         HUNT_ACCEPTED                 = 1489, -- Hunt accepted!
         USE_SCYLDS                    = 1490, -- You use <number> [scyld/scylds]. Scyld balance: <number>.


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This ID is referenced [here](https://github.com/topaz-next/topaz/blob/9e5e8a9459e822a4071561bdb012471bcd8f61f9/scripts/zones/Aht_Urhgan_Whitegate/npcs/Imperial_Whitegate.lua#L53) but wasn't defined in the TextIDs table. [fixes #2347]
 

