### PR TITLE
use correct element for enspell damage

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -565,7 +565,7 @@ namespace battleutils
 
         damage = (int32)(damage * resist);
         damage = (int32)(damage * dBonus);
-        damage = MagicDmgTaken(PDefender, damage, (ELEMENT)(element + 1));
+        damage = MagicDmgTaken(PDefender, damage, (ELEMENT)(element));
 
         if (damage > 0)
         {
@@ -934,7 +934,7 @@ namespace battleutils
                 if (previous_daze == EFFECT_DRAIN_DAZE && PDefender->m_EcoSystem != ECOSYSTEM::UNDEAD)
                 {
                     PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_DRAIN_DAZE, 0, previous_daze_power, 0, 10, PAttacker->id), true);
-                }   
+                }
                 else
                 {
                     PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(previous_daze, 0, previous_daze_power, 0, 10, PAttacker->id), true);
@@ -1069,7 +1069,7 @@ namespace battleutils
                 if (hasDrainDaze)
                 {
                     daze = EFFECT_DRAIN_DAZE;
-                }   
+                }
                 else if (hasAspirDaze)
                 {
                     daze = EFFECT_ASPIR_DAZE;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

fixes #2358
