### PR TITLE
add set homepoint textId to Qufim, and handle if this is missing

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -261,7 +261,11 @@ tpz.homepoint.onEventFinish = function(player, csid, option, event)
         choice = bit.band(option, 0xFF)
         if choice == selection.SET_HOMEPOINT then
             player:setHomePoint()
-            player:messageSpecial(zones[player:getZoneID()].text.HOMEPOINT_SET)
+            if zones[player:getZoneID()].text.HOMEPOINT_SET then
+                player:messageSpecial(zones[player:getZoneID()].text.HOMEPOINT_SET)
+            else
+                print(string.format("ERROR: missing ID.text.HOMEPOINT_SET in zone %s.", player:getZoneName()))
+            end
         elseif (choice == selection.TELEPORT or choice == selection.SAME_ZONE) and HOMEPOINT_TELEPORT == 1 then
             goToHP(player, choice, bit.rshift(option, 16))
         end

--- a/scripts/zones/Qufim_Island/IDs.lua
+++ b/scripts/zones/Qufim_Island/IDs.lua
@@ -26,6 +26,7 @@ zones[tpz.zone.QUFIM_ISLAND] =
         THESE_WITHERED_FLOWERS         = 7328,  -- These withered flowers seem unable to bloom.
         NOW_THAT_NIGHT_HAS_FALLEN      = 7329,  -- Now that night has fallen, the flowers bloom with a strange glow.
         CONQUEST                       = 7377,  -- You've earned conquest points!
+        HOMEPOINT_SET                  = 7471,  -- Your home point has been set.
         AN_EMPTY_LIGHT_SWIRLS          = 7754,  -- An empty light swirls about the cave, eating away at the surroundings...
         GIGANTIC_FOOTPRINT             = 7838,  -- There is a gigantic footprint here.
         DYNA_NPC_DEFAULT_MESSAGE       = 7852,  -- You hear a mysterious, floating voice: Bring forth the <item>...


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

fixes #2380 