### PR TITLE
Missing Mousses in Den of Rancor

### DIFF
--- a/scripts/zones/Den_of_Rancor/mobs/Mousse.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Mousse.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Den of Rancor
+--  Mob: Mousse
+-----------------------------------
+require("scripts/globals/regimes")
+-----------------------------------
+
+function onMobDeath(mob, player, isKiller)
+    tpz.regime.checkRegime(player, mob, 797, 2, tpz.regime.type.GROUNDS)
+end


### PR DESCRIPTION
Mousses' script is missing and necessary, as they are a target in a Grounds of Valor regime number 797 for Den of Rancor. Quick, simple fix to allow them to give credit for the regime. They are the 2nd mob in 797, paired with Dire Bats.

https://ffxiclopedia.fandom.com/wiki/Grounds_Tome

>             [tpz.zone.DEN_OF_RANCOR] =
>             {
>                 event = 13,
>                 page =
>                 {
>                     { 3, 3, 0, 0, 60, 64, 1370, 796},
>                     { 4, 2, 0, 0, 60, 67, 1500, 797},
>                     { 6, 0, 0, 0, 62, 69, 1820, 798},
>                     { 4, 2, 0, 0, 62, 69, 1640, 799},
>                     { 4, 2, 0, 0, 62, 76, 1650, 800},
>                     { 5, 1, 0, 0, 73, 81, 1690, 801},
>                     { 3, 3, 0, 0, 74, 79, 1640, 802},
>                     { 4, 2, 0, 0, 75, 80, 1790, 803},
>                 },
>             },



<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
