### PR TITLE
added missing progress value and changed to use local var

### DIFF
--- a/scripts/zones/Aydeewa_Subterrane/npcs/blank_omens.lua
+++ b/scripts/zones/Aydeewa_Subterrane/npcs/blank_omens.lua
@@ -11,7 +11,12 @@ function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    if player:getCharVar("OmensProgress") == 4 then
+    local omensProgress = player:getCharVar("OmensProgress")
+
+    if
+        omensProgress == 3 or
+        omensProgress == 4
+    then
         player:startEvent(9)
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)


### PR DESCRIPTION
lathuya uses omensProgress = 3 if you talk to her only once
and omensProgress = 4 if you talk to her a second time
which was not taken into consideration before. Which made
PCs have to travel back to her and back to blank_omens

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
