### PR TITLE
Additional fixes to sneak trades

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -722,8 +722,8 @@ tpz.caskets.onTrade = function(player, npc, trade)
     local chestOwner        = npc:getLocalVar("[caskets]PARTYID")         -- the id of the player, party or alliance that has rights to the chest.
     local leaderId          = player:getLeaderID()
 
-    -- Trading a casket should remove sneak + invisible
-    player:delStatusEffect(tpz.effect.SNEAK)
+    -- NOTE: The client blocks actions like this while invisible, but it's very easy to inject an action packet to get 
+    -- around this restriction. Strip invisible to make sure that case is covered.
     player:delStatusEffect(tpz.effect.INVISIBLE)
 
     if leaderId ~= chestOwner then

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -722,8 +722,9 @@ tpz.caskets.onTrade = function(player, npc, trade)
     local chestOwner        = npc:getLocalVar("[caskets]PARTYID")         -- the id of the player, party or alliance that has rights to the chest.
     local leaderId          = player:getLeaderID()
 
-    -- Trading a casket should remove sneak
+    -- Trading a casket should remove sneak + invisible
     player:delStatusEffect(tpz.effect.SNEAK)
+    player:delStatusEffect(tpz.effect.INVISIBLE)
 
     if leaderId ~= chestOwner then
         return

--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1402,6 +1402,9 @@ tpz.helm.onTrade = function(player, npc, trade, helmType, csid)
     local zoneId = player:getZoneID()
     local regionId = player:getCurrentRegion()
 
+    -- HELM should remove invisible
+    player:delStatusEffect(tpz.effect.INVISIBLE)
+
     if trade:hasItemQty(info.tool, 1) and trade:getItemCount() == 1 then
         -- start event
         local item  = pickItem(player, info)

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1334,8 +1334,9 @@ tpz.treasure.onTrade = function(player, npc, trade, chestType)
     local activeHands = player:getCharVar("BorghertzAlreadyActiveWithJob")
     local illusionCooldown  = npc:getLocalVar("illusionCooldown")
     
-    -- Trading a treasure should remove sneak
+    -- Trading a casket should remove sneak + invisible
     player:delStatusEffect(tpz.effect.SNEAK)
+    player:delStatusEffect(tpz.effect.INVISIBLE)
 
     -- determine type of key traded
     local keyTraded = nil

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1334,9 +1334,11 @@ tpz.treasure.onTrade = function(player, npc, trade, chestType)
     local activeHands = player:getCharVar("BorghertzAlreadyActiveWithJob")
     local illusionCooldown  = npc:getLocalVar("illusionCooldown")
     
-    -- Trading a casket should remove sneak + invisible
-    player:delStatusEffect(tpz.effect.SNEAK)
+    -- NOTE: The client blocks actions like this while invisible, but it's very easy to inject an action packet to get 
+    -- around this restriction. Strip invisible to make sure that case is covered.
     player:delStatusEffect(tpz.effect.INVISIBLE)
+    -- Interacting with Treasures and Coffers drops Sneak
+    player:delStatusEffect(tpz.effect.SNEAK)
 
     -- determine type of key traded
     local keyTraded = nil

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1170,6 +1170,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE)) 
         {
             // 155 = "You cannot perform that action on the specified target."
+            // TODO: Correct message is "You cannot use that command while invisible."
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
             return;
         }
@@ -1419,6 +1420,16 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x036(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
+
+     // If PChar is invisible don't allow the trade, but you are able to initiate a trade TO an invisible player
+    if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
+    {
+        // 155 = "You cannot perform that action on the specified target."
+        // TODO: Correct message is "You cannot use that command while invisible."
+        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
+        return;
+    }
+
     uint32 npcid  = data.ref<uint32>(0x04);
     uint16 targid = data.ref<uint16>(0x3A);
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work


- HELM now correctly removes invisible
- Trading Caskets and Treasures now correctly removes both Sneak and Invis

Tested and verified working.