### PR TITLE
GEO merit category additions and crash fix

### DIFF
--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -116,6 +116,8 @@ static const MeritCategoryInfo_t meritCatInfo[] = {
 
     { 14, 15, 8 }, // MCATEGORY_WS
 
+    { 5, 10, 6 }, // MCATEGORY_GEO_1
+
     { 0, 0, 8 }, // MCATEGORY_UNK_0	26
     { 0, 0, 8 }, // MCATEGORY_UNK_1
     { 0, 0, 8 }, // MCATEGORY_UNK_2
@@ -142,6 +144,7 @@ static const MeritCategoryInfo_t meritCatInfo[] = {
     { 4, 10, 7 },  // MCATEGORY_PUP_2
     { 4, 10, 7 },  // MCATEGORY_DNC_2
     { 6, 10, 7 },  // MCATEGORY_SHC_2
+    { 4, 10, 7 },  // MCATEGORY_GEO_2
 };
 
 #define GetMeritCategory(merit) (((merit) >> 6) - 1)  // получаем категорию из merit
@@ -195,9 +198,9 @@ void CMeritPoints::LoadMeritPoints(uint32 charid)
 
     for (uint16 i = 0; i < MERITS_COUNT; ++i)
     {
-        if ((catNumber < 51 && i == meritNameSpace::groupOffset[catNumber]) || (catNumber > 25 && catNumber < 31))
+        if ((catNumber < 54 && i == meritNameSpace::groupOffset[catNumber]) || (catNumber > 26 && catNumber < 31) || catNumber == 51)
         {
-            if (catNumber > 25 && catNumber < 31)
+            if (catNumber > 26 && catNumber < 31 || catNumber == 51)
             { // point these to valid merits to prevent crash
                 Categories[catNumber] = &merits[163];
             }


### PR DESCRIPTION
• added MCATEGORY_GEO_1
• added MCATEGORY_GEO_2
• adjusted LoadMeritPoints to accommodate the added category additions

This fixes Issue: #2418

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
