### PR TITLE
fix array lookups for resist mod, day/weather, obis when calculating enspell damage

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -501,7 +501,7 @@ namespace battleutils
         Mod     resistarray[8] = { Mod::FIRERES, Mod::ICERES, Mod::WINDRES, Mod::EARTHRES, Mod::THUNDERRES, Mod::WATERRES, Mod::LIGHTRES, Mod::DARKRES };
         bool    obiBonus       = false;
 
-        double half      = (double)(PDefender->getMod(resistarray[element])) / 100;
+        double half      = (double)(PDefender->getMod(resistarray[element - 1])) / 100;
         double quart     = pow(half, 2);
         double eighth    = pow(half, 3);
         double sixteenth = pow(half, 4);
@@ -528,7 +528,7 @@ namespace battleutils
         if (PAttacker->objtype == TYPE_PC)
         {
             CItemEquipment* waist = ((CCharEntity*)PAttacker)->getEquip(SLOT_WAIST);
-            if (waist && waist->getID() == obi[element])
+            if (waist && waist->getID() == obi[element - 1])
             {
                 obiBonus = true;
             }
@@ -538,27 +538,27 @@ namespace battleutils
             // mobs random multiplier
             dBonus += tpzrand::GetRandomNumber(100) / 1000.0f;
         }
-        if (WeekDay == strongDay[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        if (WeekDay == strongDay[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus += 0.1f;
         }
-        else if (WeekDay == weakDay[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        else if (WeekDay == weakDay[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus -= 0.1f;
         }
-        if (weather == strongWeatherSingle[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        if (weather == strongWeatherSingle[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus += 0.1f;
         }
-        else if (weather == strongWeatherDouble[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        else if (weather == strongWeatherDouble[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus += 0.25f;
         }
-        else if (weather == weakWeatherSingle[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        else if (weather == weakWeatherSingle[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus -= 0.1f;
         }
-        else if (weather == weakWeatherDouble[element] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
+        else if (weather == weakWeatherDouble[element - 1] && (obiBonus || tpzrand::GetRandomNumber(100) < 33))
         {
             dBonus -= 0.25f;
         }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Follow up to #2377.
Fixes #2358.

All these arrays have fire at 0-index, but elements have fire at 1-index.  So when calculating damage, we have to subtract one to get the correct resistance mod, obi, and so forth.