### PR TITLE
[sol refactor] table pets functions

### DIFF
--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -1,10 +1,9 @@
 -----------------------------------
 -- PET: Automaton
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/pets")
+local entity = {}
 
-function onMobSpawn(mob)
+entity.onMobSpawn = function(mob)
     mob:setLocalVar("MANEUVER_DURATION", 60)
     mob:addListener("EFFECTS_TICK", "MANEUVER_DURATION", function(automaton)
         if (automaton:getTarget()) then
@@ -14,6 +13,8 @@ function onMobSpawn(mob)
     end)
 end
 
-function onMobDeath(mob)
+entity.onMobDeath = function(mob)
     mob:removeListener("MANEUVER_DURATION")
 end
+
+return entity

--- a/scripts/globals/pets/luopan.lua
+++ b/scripts/globals/pets/luopan.lua
@@ -1,15 +1,14 @@
- -----------------------------------
+-----------------------------------
 -- PET: Luopan
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/pets")
-require("scripts/globals/msg")
------------------------------------
+local entity = {}
 
-function onMobSpawn(mob)
+entity.onMobSpawn = function(mob)
     -- BGWIKI: "Regardless of perpetuation cost reduction, Luopans have a maximum duration of 10 minutes."
     mob:timer(600000, function(mob) mob:setHP(0) end)
 end
 
-function onMobDeath(mob)
+entity.onMobDeath = function(mob)
 end
+
+return entity

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -1,9 +1,11 @@
 -----------------------------------
 --  PET: Wyvern
 -----------------------------------
-require("scripts/globals/status")
 require("scripts/globals/ability")
+require("scripts/globals/status")
 require("scripts/globals/msg")
+-----------------------------------
+local entity = {}
 
 local WYVERN_OFFENSIVE = 1
 local WYVERN_DEFENSIVE = 2
@@ -35,7 +37,7 @@ local wyvernTypes =
     [tpz.job.RUN] = WYVERN_MULTI,
 }
 
-function doHealingBreath(player, threshold, breath)
+local function doHealingBreath(player, threshold, breath)
     local breath_heal_range = 13
     local function inBreathRange(target)
         return player:getPet():getZoneID() == target:getZoneID() and player:getPet():checkDistance(target) <= breath_heal_range
@@ -54,7 +56,7 @@ function doHealingBreath(player, threshold, breath)
     end
 end
 
-function doStatusBreath(target, player)
+local function doStatusBreath(target, player)
     local usedBreath = true
     local wyvern = player:getPet()
 
@@ -75,7 +77,7 @@ function doStatusBreath(target, player)
     return usedBreath
 end
 
-function onMobSpawn(mob)
+entity.onMobSpawn = function(mob)
     local master = mob:getMaster()
     mob:addMod(tpz.mod.DMG, -40)
     if master:getMod(tpz.mod.WYVERN_SUBJOB_TRAITS) > 0 then
@@ -206,7 +208,7 @@ function onMobSpawn(mob)
     end)
 end
 
-function onMobDeath(mob, player)
+entity.onMobDeath = function(mob, player)
     local master = mob:getMaster()
     local numLvls = mob:getLocalVar("level_Ups")
     if numLvls ~= 0 then
@@ -220,3 +222,5 @@ function onMobDeath(mob, player)
     master:removeListener("PET_WYVERN_DISENGAGE")
     master:removeListener("PET_WYVERN_EXP")
 end
+
+return entity


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

* Add entity table to the three scripts in globals/pets
* Move the functions onto the table
* Local some functions
* Remove unused requires
