### PR TITLE
Fix being always uneligible to get guild points

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -115,7 +115,7 @@ std::pair<uint16, uint16> CGuild::getDailyGPItem(CCharEntity* PChar)
 
     auto GPItem    = m_GPItems[rank - 3];
     auto curPoints = (uint16)charutils::GetCharVar(PChar, "[GUILD]daily_points");
-    if (curPoints < 0) // char_var set to -1 in crefting.lua file. Deleted in guildutils.cpp
+    if (curPoints < 0) // char_var set to -1 in crafting.lua file. Deleted in guildutils.cpp
     {
         return std::make_pair(GPItem[0].item->getID(), 0);
     }

--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -115,7 +115,7 @@ std::pair<uint16, uint16> CGuild::getDailyGPItem(CCharEntity* PChar)
 
     auto GPItem    = m_GPItems[rank - 3];
     auto curPoints = (uint16)charutils::GetCharVar(PChar, "[GUILD]daily_points");
-    if (curPoints == 0)
+    if (curPoints < 0) // char_var set to -1 in crefting.lua file. Deleted in guildutils.cpp
     {
         return std::make_pair(GPItem[0].item->getID(), 0);
     }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Small edit to guild.cpp to fix never being able to get Guild Points.

Originally checked for -1, but it was changed to check for 0 on this commit: 
https://github.com/topaz-next/topaz/commit/aec303703a386b9557c97e77ce2bf7da1e14e713#diff-c2ea48c79daa9d9cf49a6bec202046a1f5e98ad80310a5d4609197fb25d1e9ee

Closes #2287