### PR TITLE
[sol refactor] remove old damage_gauge functions; use new ones

### DIFF
--- a/scripts/globals/abilities/pets/attachments/damage_gauge.lua
+++ b/scripts/globals/abilities/pets/attachments/damage_gauge.lua
@@ -7,44 +7,6 @@ require("scripts/globals/status")
 local attachment_object = {}
 
 attachment_object.onEquip = function(pet)
-    pet:setLocalVar("damagegauge", 1)
-    pet:addMod(tpz.mod.AUTO_HEALING_THRESHOLD, 20)
-    pet:addMod(tpz.mod.AUTO_HEALING_DELAY, 3)
-end
-
-attachment_object.onUnequip = function(pet)
-    pet:setLocalVar("damagegauge", 0)
-    pet:delMod(tpz.mod.AUTO_HEALING_THRESHOLD, 20)
-    pet:delMod(tpz.mod.AUTO_HEALING_DELAY, 3)
-end
-
-attachment_object.onManeuverGain = function(pet, maneuvers)
-    if maneuvers == 1 then
-        pet:addMod(tpz.mod.AUTO_HEALING_THRESHOLD, 20)
-        pet:addMod(tpz.mod.AUTO_HEALING_DELAY, 3)
-    elseif maneuvers == 2 then
-        pet:addMod(tpz.mod.AUTO_HEALING_THRESHOLD, 10)
-        pet:addMod(tpz.mod.AUTO_HEALING_DELAY, 2)
-    elseif maneuvers == 3 then
-        pet:addMod(tpz.mod.AUTO_HEALING_THRESHOLD, 10)
-        pet:addMod(tpz.mod.AUTO_HEALING_DELAY, 2)
-    end
-end
-
-attachment_object.onManeuverLose = function(pet, maneuvers)
-    if maneuvers == 1 then
-        pet:delMod(tpz.mod.AUTO_HEALING_THRESHOLD, 20)
-        pet:delMod(tpz.mod.AUTO_HEALING_DELAY, 3)
-    elseif maneuvers == 2 then
-        pet:delMod(tpz.mod.AUTO_HEALING_THRESHOLD, 10)
-        pet:delMod(tpz.mod.AUTO_HEALING_DELAY, 2)
-    elseif maneuvers == 3 then
-        pet:delMod(tpz.mod.AUTO_HEALING_THRESHOLD, 10)
-        pet:delMod(tpz.mod.AUTO_HEALING_DELAY, 2)
-    end
-end
-
-attachment_object.onEquip = function(pet)
     onUpdate(pet, 0)
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
