### PR TITLE
[WIP] Instance Refactor

### DIFF
--- a/scripts/commands/testinstance.lua
+++ b/scripts/commands/testinstance.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- func: !testinstance <instance_id>
+-- desc: Load an instance and take you there
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "i"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!testinstance <instance_id>")
+end
+
+function onTrigger(player, instance_id)
+    player:createInstance(instance_id)
+    player:PrintToPlayer(string.format("Going to instance %d in 5 seconds...", instance_id))
+    player:timer(5000, function(player)
+        local instance = player:getInstance()
+        player:PrintToPlayer(string.format("Going to %s...", instance:getName()))
+        player:instanceEntry(player, 1)
+    end)
+end

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
@@ -98,7 +98,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(58, 77)
+        player:createInstance(58)
     elseif nashmeirasPlea == 1 then
 
         if party ~= nil then
@@ -117,7 +117,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(59, 77)
+        player:createInstance(59)
     else
 
         if party ~= nil then
@@ -136,7 +136,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(player:getCurrentAssault(), 77)
+        player:createInstance(player:getCurrentAssault())
     end
 
 end

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20t.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20t.lua
@@ -51,7 +51,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(instanceid, 76)
+    player:createInstance(instanceid)
 
 end
 

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
@@ -53,7 +53,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(instanceid, 74)
+    player:createInstance(instanceid)
 
 end
 

--- a/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
@@ -43,7 +43,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(53, 60)
+        player:createInstance(53)
         player:setLocalVar("theblackcoffinfight", 0)
 
         elseif player:getLocalVar("againstalloddsfight") == 1 then
@@ -57,7 +57,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(54, 60)
+        player:createInstance(54)
         player:setLocalVar("againstalloddsfight", 0)
     end
 end

--- a/scripts/zones/Arrapago_Reef/npcs/_jic.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jic.lua
@@ -60,7 +60,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(player:getCurrentAssault(), 55)
+    player:createInstance(player:getCurrentAssault())
 
 end
 

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g2.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g2.lua
@@ -60,7 +60,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(player:getCurrentAssault(), 66)
+    player:createInstance(player:getCurrentAssault())
 
 end
 

--- a/scripts/zones/Caedarva_Mire/npcs/_272.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_272.lua
@@ -64,7 +64,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(player:getCurrentAssault(), 69)
+    player:createInstance(player:getCurrentAssault())
 
 end
 

--- a/scripts/zones/Caedarva_Mire/npcs/_273.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_273.lua
@@ -79,7 +79,7 @@ entity.onEventUpdate = function(player, csid, option, target)
             end
         end
 
-        player:createInstance(player:getCurrentAssault(), 56)
+        player:createInstance(player:getCurrentAssault())
     end
 
 end

--- a/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
@@ -57,7 +57,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         end
     end
 
-    player:createInstance(player:getCurrentAssault(), 63)
+    player:createInstance(player:getCurrentAssault())
 end
 
 entity.onEventFinish = function(player, csid, option, target)

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -32,11 +32,19 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "lua/luautils.h"
 #include "mob_modifier.h"
 #include "mob_spell_list.h"
+#include "utils/instanceutils.h"
 #include "utils/mobutils.h"
+#include "utils/zoneutils.h"
 
-CInstanceLoader::CInstanceLoader(uint8 instanceid, CZone* PZone, CCharEntity* PRequester)
+CInstanceLoader::CInstanceLoader(uint8 instanceid, CCharEntity* PRequester)
 {
-    TPZ_DEBUG_BREAK_IF(PZone->GetType() != ZONE_TYPE::DUNGEON_INSTANCED);
+    CZone* PZone = zoneutils::GetZone(instanceutils::GetInstanceData(instanceid).instance_zone);
+
+    if (!PZone || PZone->GetType() != ZONE_TYPE::DUNGEON_INSTANCED)
+    {
+        ShowError("Invalid zone for instanceid: %d", instanceid);
+        return;
+    }
 
     requester           = PRequester;
     zone                = PZone;

--- a/src/map/instance_loader.h
+++ b/src/map/instance_loader.h
@@ -35,7 +35,7 @@ class CZone;
 class CInstanceLoader
 {
 public:
-    CInstanceLoader(uint8 instanceid, CZone* PZone, CCharEntity* PRequester);
+    CInstanceLoader(uint8 instanceid, CCharEntity* PRequester);
     ~CInstanceLoader();
 
     CInstance* GetInstance();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7989,15 +7989,15 @@ void CLuaBaseEntity::setInstance(CLuaInstance* PLuaInstance)
 /************************************************************************
  *  Function: createInstance()
  *  Purpose : Creates a new instance for a PC
- *  Example : player:createInstance(player:getCurrentAssault(), 63)
+ *  Example : player:createInstance(player:getCurrentAssault())
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::createInstance(uint8 instanceID, uint16 zoneID)
+void CLuaBaseEntity::createInstance(uint8 instanceID)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    instanceutils::LoadInstance(instanceID, zoneID, static_cast<CCharEntity*>(m_PBaseEntity));
+    instanceutils::LoadInstance(instanceID, static_cast<CCharEntity*>(m_PBaseEntity));
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -465,7 +465,7 @@ public:
     // Instances
     auto getInstance() -> std::optional<CLuaInstance>;
     void setInstance(CLuaInstance* PLuaInstance);
-    void createInstance(uint8 instanceID, uint16 zoneID);
+    void createInstance(uint8 instanceID);
     void instanceEntry(CLuaBaseEntity* PLuaBaseEntity, uint32 response);
     // int32 isInAssault(lua_Stat*); // If player is in a Instanced Assault Dungeon returns true --- Not Implemented
 

--- a/src/map/lua/lua_instance.cpp
+++ b/src/map/lua/lua_instance.cpp
@@ -43,6 +43,11 @@ uint8 CLuaInstance::getID()
     return m_PLuaInstance->GetID();
 }
 
+std::string CLuaInstance::getName()
+{
+    return (const char*)m_PLuaInstance->GetName();
+}
+
 sol::table CLuaInstance::getAllies()
 {
     auto table = luautils::lua.create_table();
@@ -221,6 +226,7 @@ void CLuaInstance::Register()
 {
     SOL_USERTYPE("CInstance", CLuaInstance);
     SOL_REGISTER("getID", CLuaInstance::getID);
+    SOL_REGISTER("getName", CLuaInstance::getName);
     SOL_REGISTER("setLevelCap", CLuaInstance::setLevelCap);
     SOL_REGISTER("getAllies", CLuaInstance::getAllies);
     SOL_REGISTER("getChars", CLuaInstance::getChars);

--- a/src/map/lua/lua_instance.h
+++ b/src/map/lua/lua_instance.h
@@ -40,6 +40,7 @@ public:
     }
 
     uint8  getID();
+    auto   getName() -> std::string;
     auto   getAllies() -> sol::table;
     auto   getChars() -> sol::table;
     auto   getMobs() -> sol::table;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -80,6 +80,7 @@
 #include "../transport.h"
 #include "../utils/battleutils.h"
 #include "../utils/charutils.h"
+#include "../utils/instanceutils.h"
 #include "../utils/itemutils.h"
 #include "../utils/zoneutils.h"
 #include "../vana_time.h"
@@ -3463,11 +3464,13 @@ namespace luautils
     {
         TracyZoneScoped;
 
+        auto instanceData = instanceutils::GetInstanceData(PInstance->GetID());
+
         auto onInstanceCreated = GetCacheEntryFromFilename(PChar->m_event.Script)["onInstanceCreated"];
         if (!onInstanceCreated.valid())
         {
-            // If you can't load from PChar->m_event.Script, try from the zone
-            auto filename     = fmt::format("./scripts/zones/{}/Zone.lua", PChar->loc.zone->GetName());
+            // If you can't load from PChar->m_event.Script, try from the entrance zone
+            auto filename     = fmt::format("./scripts/zones/{}/Zone.lua", instanceData.entrance_zone_name);
             onInstanceCreated = GetCacheEntryFromFilename(filename)["onInstanceCreated"];
             if (!onInstanceCreated.valid())
             {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -253,7 +253,7 @@ int32 do_init(int32 argc, char** argv)
     ShowMessage("\t\t\t - " CL_GREEN "[OK]" CL_RESET "\n");
 
     fishingutils::LoadFishingMessages();
-    instanceutils::CacheInstanceScripts();
+    instanceutils::LoadInstanceList();
 
     ShowStatus("do_init: server is binding with port %u", map_port == 0 ? map_config.usMapPort : map_port);
     map_fd = makeBind_udp(map_config.uiMapIp, map_port == 0 ? map_config.usMapPort : map_port);

--- a/src/map/utils/instanceutils.cpp
+++ b/src/map/utils/instanceutils.cpp
@@ -30,6 +30,64 @@ std::unique_ptr<CInstanceLoader> Loader;
 
 namespace instanceutils
 {
+    std::unordered_map<uint16, InstanceData_t> InstanceData;
+
+    void LoadInstanceList()
+    {
+        const char query[] =
+            "SELECT "
+            "instanceid,"    // 0
+            "instance_name," // 1
+            "instance_zone," // 2
+            "entrance_zone," // 3
+            "time_limit,"    // 4
+            "start_x,"       // 5
+            "start_y,"       // 6
+            "start_z,"       // 7
+            "start_rot,"     // 8
+            "music_day,"     // 9
+            "music_night,"   // 10
+            "battlesolo,"    // 11
+            "battlemulti "   // 12
+            "FROM instance_list;";
+
+        int32 ret = Sql_Query(SqlHandle, query);
+
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+        {
+            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+            {
+                InstanceData_t data;
+
+                // Main data
+                data.id            = static_cast<uint16>(Sql_GetIntData(SqlHandle, 0));
+                data.instance_name = reinterpret_cast<const char*>(Sql_GetData(SqlHandle, 1));
+                data.instance_zone = static_cast<uint16>(Sql_GetIntData(SqlHandle, 2));
+                data.entrance_zone = static_cast<uint16>(Sql_GetIntData(SqlHandle, 3));
+                data.time_limit    = static_cast<uint16>(Sql_GetIntData(SqlHandle, 4));
+                data.start_x       = static_cast<float>(Sql_GetFloatData(SqlHandle, 5));
+                data.start_y       = static_cast<float>(Sql_GetFloatData(SqlHandle, 6));
+                data.start_z       = static_cast<float>(Sql_GetFloatData(SqlHandle, 7));
+                data.start_rot     = static_cast<uint16>(Sql_GetIntData(SqlHandle, 8));
+                data.music_day     = static_cast<uint16>(Sql_GetIntData(SqlHandle, 9));
+                data.music_night   = static_cast<uint16>(Sql_GetIntData(SqlHandle, 10));
+                data.battlesolo    = static_cast<uint16>(Sql_GetIntData(SqlHandle, 11));
+                data.battlemulti   = static_cast<uint16>(Sql_GetIntData(SqlHandle, 12));
+
+                // Meta data
+                data.instance_zone_name = reinterpret_cast<const char*>(zoneutils::GetZone(data.instance_zone)->GetName());
+                data.entrance_zone_name = reinterpret_cast<const char*>(zoneutils::GetZone(data.entrance_zone)->GetName());
+                data.filename = fmt::format("./scripts/zones/{}/instances/{}.lua", data.instance_zone, data.instance_name);
+
+                // Add to data cache
+                InstanceData[data.id] = data;
+
+                // Add to Lua cache
+                luautils::CacheLuaObjectFromFile(data.filename);
+            }
+        }
+    }
+
     void CheckInstance()
     {
         if (Loader)
@@ -42,12 +100,11 @@ namespace instanceutils
         }
     }
 
-    void LoadInstance(uint8 instanceid, uint16 zoneid, CCharEntity* PRequester)
+    void LoadInstance(uint8 instanceid, CCharEntity* PRequester)
     {
-        CZone* PZone = zoneutils::GetZone(zoneid);
-        if (!Loader && PZone)
+        if (!Loader)
         {
-            Loader = std::make_unique<CInstanceLoader>(instanceid, PZone, PRequester);
+            Loader = std::make_unique<CInstanceLoader>(instanceid, PRequester);
         }
         else
         {
@@ -55,28 +112,8 @@ namespace instanceutils
         }
     }
 
-    void CacheInstanceScripts()
+    InstanceData_t GetInstanceData(uint8 instanceid)
     {
-        /*
-        // TODO: instance_zone needs to be added to the db
-        const char query[] = "SELECT instance_name, instance_zone FROM instance_list;";
-
-        int32 ret = Sql_Query(SqlHandle, query);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
-        {
-            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-            {
-                std::string instance_name = (const char*)Sql_GetData(SqlHandle, 0);
-                uint16      zone_id       = Sql_GetIntData(SqlHandle, 1);
-
-                std::string zone_name = (const char*)(zoneutils::GetZone(zone_id)->GetName());
-
-                auto filename = fmt::format("./scripts/zones/{}/instances/{}.lua", zone_name, instance_name);
-
-                luautils::CacheLuaObjectFromFile(filename);
-            }
-        }
-        */
+        return InstanceData[instanceid];
     }
 }; // namespace instanceutils

--- a/src/map/utils/instanceutils.h
+++ b/src/map/utils/instanceutils.h
@@ -27,11 +27,32 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 class CInstanceLoader;
 class CCharEntity;
 
+struct InstanceData_t
+{
+    uint16      id;
+    std::string instance_name;
+    uint16      instance_zone;
+    std::string instance_zone_name;
+    uint16      entrance_zone;
+    std::string entrance_zone_name;
+    uint16      time_limit;
+    float       start_x;
+    float       start_y;
+    float       start_z;
+    uint16      start_rot;
+    uint16      music_day;
+    uint16      music_night;
+    uint16      battlesolo;
+    uint16      battlemulti;
+    std::string filename;
+};
+
 namespace instanceutils
 {
+    void LoadInstanceList();
     void CheckInstance();
-    void LoadInstance(uint8 instanceid, uint16 zoneid, CCharEntity* PRequester);
-    void CacheInstanceScripts();
+    void LoadInstance(uint8 instanceid, CCharEntity* PRequester);
+    auto GetInstanceData(uint8 instanceid) -> InstanceData_t;
 }; // namespace instanceutils
 
 #endif


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

I mentioned a couple of ideas I had about how we handle and test instances in Discord a few days ago, and wanted to get some of them written down before they evaporated out of my mind.

**Goals**

Instances are massively important in mid-late TOAU content, and all expansions from TOAU onwards use them heavily. Since instances are "on-demand", they should be easy to write, spin up, and test.

- Introduce `!testinstance x`, which will spin up your chosen instance a put you in there
- (Did in earlier PR) Add more information to instance db entries (+migration script)
- Simplify `player:createInstance` interface
- Data and Lua cache instance information
- Consolidate instance code to just the instance file

**TODO**
- Finish hooking up `!testinstance`
- There are **TWO** instances of OnInstanceCreated: one for when the instance object is created, and one as a callback for when it's ready. The seconds one NEEDS to be changed to "OnInstanceReadyCallback" or something, it's confusing right now.
- There is a _lot_ of instance handling information in the "OnTrigger" NPC where you enter the instance from. I want to move that into the instance script itself. This helps with the "go to instance from any zone" plan.
