### PR TITLE
fix template formatting - need the space for checkable box

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-<!-- place 'x' mark between square [] brackets to checkmark box -->
-- [] I have searched existing issues (https://github.com/topaz-next/topaz/issues) to see if the issue has already been opened
-- [] I have checked the commit log to see if the issue has been resolved since my server was last updated
-- [] This issue occurs on `release` branch (if other branch, please specify)
+<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
+- [ ] I have searched existing issues (https://github.com/topaz-next/topaz/issues) to see if the issue has already been opened
+- [ ] I have checked the commit log to see if the issue has been resolved since my server was last updated
+- [ ] This issue occurs on `release` branch (if other branch, please specify)
 
 **_Additional Information_** (Steps to reproduce/Expected behavior) **:** 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-<!-- place 'x' mark between square [] brackets to affirm: -->
+<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
 **_I affirm:_**
-- [] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
-- [] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
-- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
+- [ ] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
+- [ ] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
+- [ ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
 
 **_Temporary_**:
-- [] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
+- [ ] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work


### PR DESCRIPTION
you save then click with the mouse, or replace the space with the x before saving

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

----


**_comparison:_**
- [] no space
- [ ] with space
