### PR TITLE
[sol refactor] update textId comments

### DIFF
--- a/scripts/zones/Bastok_Markets/IDs.lua
+++ b/scripts/zones/Bastok_Markets/IDs.lua
@@ -17,7 +17,7 @@ zones[tpz.zone.BASTOK_MARKETS] =
         KEYITEM_OBTAINED             = 6392, -- Obtained key item: <keyitem>.
         KEYITEM_LOST                 = 6393, -- Lost key item: <keyitem>.
         NOT_HAVE_ENOUGH_GIL          = 6394, -- You do not have enough gil.
-        YOU_OBTAIN_ITEM              = 6395, -- You obtain <amount or 'a'> <item>(s)!
+        YOU_OBTAIN_ITEM              = 6395, -- You obtain  <item>!
         YOU_MUST_WAIT_ANOTHER_N_DAYS = 6425, -- You must wait another <number> [day/days] to perform that action.
         ITEMS_OBTAINED               = 6398, -- You obtain <number> <item>!
         CARRIED_OVER_POINTS          = 6428, -- You have carried over <number> login point[/s].
@@ -69,7 +69,7 @@ zones[tpz.zone.BASTOK_MARKETS] =
         TURNING_IN_SPARKS            = 14206, -- Ohohoho... Turning in sparks, I see.
         DO_NOT_POSSESS_ENOUGH        = 14230, -- You do not possess enough <item> to complete the transaction.
         NOT_ENOUGH_SPARKS            = 14231, -- You do not possess enough sparks of eminence to complete the transaction.
-        MAX_SPARKS_LIMIT_REACHED     = 14232, -- You have reached the maximum number of sparks that you can exchange this week (<number>)
+        MAX_SPARKS_LIMIT_REACHED     = 14232, -- You have reached the maximum number of sparks that you can exchange this week (<number>). Your ability to purchase skill books and equipment will be restricted until next week.
         YOU_NOW_HAVE_AMT_CURRENCY    = 14242, -- You now have <number> [sparks of eminence/conquest points/points of imperial standing/Allied Notes/bayld/Fields of Valor points/assault points (Leujaoam)/assault points (Mamool Ja Training Grounds)/assault points (Lebros Cavern)/assault points (Periqia)/assault points (Ilrusi Atoll)/cruor/kinetic units/obsidian fragments/mweya plasm corpuscles/ballista points/Unity accolades/pinches of Escha silt/resistance credits].
     },
     mob =

--- a/scripts/zones/Southern_San_dOria/IDs.lua
+++ b/scripts/zones/Southern_San_dOria/IDs.lua
@@ -18,7 +18,7 @@ zones[tpz.zone.SOUTHERN_SAN_DORIA] =
         KEYITEM_OBTAINED               = 6436, -- Obtained key item: <keyitem>.
         KEYITEM_LOST                   = 6437, -- Lost key item: <keyitem>.
         NOT_HAVE_ENOUGH_GIL            = 6438, -- You do not have enough gil.
-        YOU_OBTAIN_ITEM                = 6439, -- You obtain <amount or 'a'> <item>(s)!
+        YOU_OBTAIN_ITEM                = 6439, -- You obtain  <item>!
         NOTHING_OUT_OF_ORDINARY        = 6447, -- There is nothing out of the ordinary here.
         YOU_MUST_WAIT_ANOTHER_N_DAYS   = 6469, -- You must wait another <number> [day/days] to perform that action.
         CARRIED_OVER_POINTS            = 6472, -- You have carried over <number> login point[/s].
@@ -96,7 +96,7 @@ zones[tpz.zone.SOUTHERN_SAN_DORIA] =
         YOU_WISH_TO_EXCHANGE_SPARKS    = 15373, -- You wish to exchange your sparks?
         DO_NOT_POSSESS_ENOUGH          = 15402, -- You do not possess enough <item> to complete the transaction.
         NOT_ENOUGH_SPARKS              = 15403, -- You do not possess enough sparks of eminence to complete the transaction.
-        MAX_SPARKS_LIMIT_REACHED       = 15404, -- You have reached the maximum number of sparks that you can exchange this week (<number>)
+        MAX_SPARKS_LIMIT_REACHED       = 15404, -- You have reached the maximum number of sparks that you can exchange this week (<number>). Your ability to purchase skill books and equipment will be restricted until next week.
         YOU_NOW_HAVE_AMT_CURRENCY      = 15414, -- You now have <number> [sparks of eminence/conquest points/points of imperial standing/Allied Notes/bayld/Fields of Valor points/assault points (Leujaoam)/assault points (Mamool Ja Training Grounds)/assault points (Lebros Cavern)/assault points (Periqia)/assault points (Ilrusi Atoll)/cruor/kinetic units/obsidian fragments/mweya plasm corpuscles/ballista points/Unity accolades/pinches of Escha silt/resistance credits].
         TEAR_IN_FABRIC_OF_SPACE        = 16558, -- There appears to be a tear in the fabric of space...
     },

--- a/scripts/zones/Western_Adoulin/IDs.lua
+++ b/scripts/zones/Western_Adoulin/IDs.lua
@@ -16,7 +16,7 @@ zones[tpz.zone.WESTERN_ADOULIN] =
         KEYITEM_OBTAINED          = 6392, -- Obtained key item: <keyitem>.
         KEYITEM_LOST              = 6393, -- Lost key item: <keyitem>.
         NOT_HAVE_ENOUGH_GIL       = 6394, -- You do not have enough gil.
-        YOU_OBTAIN_ITEM           = 6395, -- You obtain <amount or 'a'> <item>(s)!
+        YOU_OBTAIN_ITEM           = 6395, -- You obtain  <item>!
         CARRIED_OVER_POINTS       = 7000, -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY   = 7001, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!<space>
         LOGIN_NUMBER              = 7002, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
@@ -40,7 +40,7 @@ zones[tpz.zone.WESTERN_ADOULIN] =
         SPARK_EXCHANGE            = 11358, -- Hm? Oh, spark exchange... Of course.
         DO_NOT_POSSESS_ENOUGH     = 11371, -- You do not possess enough <item> to complete the transaction.
         NOT_ENOUGH_SPARKS         = 11372, -- You do not possess enough sparks of eminence to complete the transaction.
-        MAX_SPARKS_LIMIT_REACHED  = 11373, -- You have reached the maximum number of sparks that you can exchange this week (<number>)
+        MAX_SPARKS_LIMIT_REACHED  = 11373, -- You have reached the maximum number of sparks that you can exchange this week (<number>). Your ability to purchase skill books and equipment will be restricted until next week.
         YOU_NOW_HAVE_AMT_CURRENCY = 11383, -- You now have <number> [sparks of eminence/conquest points/points of imperial standing/Allied Notes/bayld/Fields of Valor points/assault points (Leujaoam)/assault points (Mamool Ja Training Grounds)/assault points (Lebros Cavern)/assault points (Periqia)/assault points (Ilrusi Atoll)/cruor/kinetic units/obsidian fragments/mweya plasm corpuscles/ballista points/Unity accolades/pinches of Escha silt/resistance credits].
     },
     mob =

--- a/scripts/zones/Windurst_Woods/IDs.lua
+++ b/scripts/zones/Windurst_Woods/IDs.lua
@@ -17,7 +17,7 @@ zones[tpz.zone.WINDURST_WOODS] =
         KEYITEM_OBTAINED             = 6551, -- Obtained key item: <keyitem>.
         KEYITEM_LOST                 = 6552, -- Lost key item: <keyitem>.
         NOT_HAVE_ENOUGH_GIL          = 6553, -- You do not have enough gil.
-        YOU_OBTAIN_ITEM              = 6554, -- You obtain <amount or 'a'> <item>(s)!
+        YOU_OBTAIN_ITEM              = 6554, -- You obtain  <item>!
         YOU_MUST_WAIT_ANOTHER_N_DAYS = 6584, -- You must wait another <number> [day/days] to perform that action.
         CARRIED_OVER_POINTS          = 6587, -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY      = 6588, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!<space>
@@ -77,7 +77,7 @@ zones[tpz.zone.WINDURST_WOODS] =
         TRRRADE_IN_SPARKS            = 13834, -- You want to trrrade in sparks, do you?
         DO_NOT_POSSESS_ENOUGH        = 13853, -- You do not possess enough <item> to complete the transaction.
         NOT_ENOUGH_SPARKS            = 13854, -- You do not possess enough sparks of eminence to complete the transaction.
-        MAX_SPARKS_LIMIT_REACHED     = 13855, -- You have reached the maximum number of sparks that you can exchange this week (<number>)
+        MAX_SPARKS_LIMIT_REACHED     = 13855, -- You have reached the maximum number of sparks that you can exchange this week (<number>). Your ability to purchase skill books and equipment will be restricted until next week.
         YOU_NOW_HAVE_AMT_CURRENCY    = 13865, -- You now have <number> [sparks of eminence/conquest points/points of imperial standing/Allied Notes/bayld/Fields of Valor points/assault points (Leujaoam)/assault points (Mamool Ja Training Grounds)/assault points (Lebros Cavern)/assault points (Periqia)/assault points (Ilrusi Atoll)/cruor/kinetic units/obsidian fragments/mweya plasm corpuscles/ballista points/Unity accolades/pinches of Escha silt/resistance credits].
     },
     mob =


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Ran these new textIds through comment-matching.  Also checked the [last few updates](http://www.playonline.com/ff11us/info/list_upd.shtml) and confirmed that none of them affect us.
