### PR TITLE
[sol refactor] update example and remove notes from two bindings in lua_baseentity

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11446,8 +11446,7 @@ bool CLuaBaseEntity::hasImmunity(uint32 immunityID)
 /************************************************************************
  *  Function: setAggressive()
  *  Purpose : Toggle a Mob to an aggressive or passive state
- *  Example : mob:setAggressive(1)
- *  Notes   : Different integer values to specify method of aggro?
+ *  Example : mob:setAggressive(true)
  ************************************************************************/
 
 void CLuaBaseEntity::setAggressive(bool aggressive)
@@ -11460,8 +11459,7 @@ void CLuaBaseEntity::setAggressive(bool aggressive)
 /************************************************************************
  *  Function: setTrueDetection()
  *  Purpose : Toggle True Detection on or off for a Mob
- *  Example : mob:setTrueDetection(1)
- *  Notes   : Different integer values for True Hearing/Sight?
+ *  Example : mob:setTrueDetection(true)
  ************************************************************************/
 
 void CLuaBaseEntity::setTrueDetection(bool truedetection)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

These bindings take bool input.  Passing different int values does not do what the notes say.
