### PR TITLE
[sol refactor] Hunts: player, death, and XP

### DIFF
--- a/scripts/globals/hunts.lua
+++ b/scripts/globals/hunts.lua
@@ -1342,6 +1342,12 @@ function tpz.hunts.onEventFinish(player, csid, option)
 end
 
 function tpz.hunts.checkHunt(mob, player, mobHuntID)
+    -- dead players and players out of XP range get no credit
+    -- also prevents error when this function is called onMobDeath from a mob not killed by a player
+    if not player or player:getHP() == 0 or player:checkDistance(mob) > 100 then
+        return
+    end
+
     local playerHuntID = player:getCharVar("[hunt]id")
 
     -- required NM has been defeated

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1291,6 +1291,7 @@ end
 tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
 
     -- dead players, or players not on this training regime, get no credit
+    -- also prevents error when this function is called onMobDeath from a mob not killed by a player
     if not player or player:getHP() == 0 or player:getCharVar("[regime]id") ~= regimeId then
         return
     end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

in tpz.hunts.checkHunt, make sure player is populated, and check for dead and ~~non-XP-receiving players~~ players outside of XP range

fixes #2439 