### PR TITLE
fix hunt registry entries that get players stuck in the menu

### DIFF
--- a/scripts/globals/hunts.lua
+++ b/scripts/globals/hunts.lua
@@ -526,9 +526,9 @@ local zone =
         [ 634] = { params = 157227, huntId = 555 },
         [ 890] = { params = 157229, huntId = 557 },
         [1146] = { params = 157230, huntId = 558 },
-        [ 634] = { params = 174633, huntId = 553 },
-        [ 890] = { params = 174636, huntId = 556 },
-        [1146] = { params = 174639, huntId = 559 },
+        [1402] = { params = 174633, huntId = 553 },
+        [1658] = { params = 174636, huntId = 556 },
+        [1914] = { params = 174639, huntId = 559 },
     },
 
     [tpz.zone.NORTHERN_SAN_DORIA] =
@@ -1242,7 +1242,7 @@ local zone =
       lock |   Scyld Qty    | NM pageId #  | status
                                           (Has distinct values) ]]--
 
-function tpz.hunts.onTrigger(player, npc, event)
+function tpz.hunts.onTrigger(player, npc)
     local huntId = player:getCharVar("[hunt]id")
     local huntStatus = player:getCharVar("[hunt]status")
     local scyldBits = bit.lshift(player:getCurrency("scyld"), 14)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Bastok_Mines/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Kazham/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Kazham/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Nashmau/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Nashmau/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Norg/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Norg/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Northern_San_dOria/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Windurst/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Port_Windurst/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Rabao/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Rabao/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/RuLude_Gardens/npcs/Hunt_Registry.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Hunt_Registry.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Hunt_Registry.lua
@@ -9,8 +9,8 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
 end
 
-entity.onTrigger = function(player, npc, event)
-    tpz.hunts.onTrigger(player, npc, event)
+entity.onTrigger = function(player, npc)
+    tpz.hunts.onTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

* remove unused event from hunt registry onTrigger
* fix three hunt entries that get players stuck in the menu