### PR TITLE
Re-fix mobspeed coz I dun derped.

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -423,30 +423,24 @@ bool CPathFind::OnPoint() const
 
 float CPathFind::GetRealSpeed()
 {
-    uint8 baseSpeed = m_PTarget->speed;
+    uint8 realSpeed = m_PTarget->speed;
 
-    // Lets not factor in player map conf or mod's to non players.
-    // (Mobs should just have speed set directly instead, and NPC's don't have mods)
-    if (m_PTarget->objtype == TYPE_PC)
+    // 'GetSpeed()' factors in movement bonuses such as map confs and modifiers.
+    if (m_PTarget->objtype != TYPE_NPC)
     {
-        baseSpeed = ((CBattleEntity*)m_PTarget)->GetSpeed();
+        realSpeed = ((CBattleEntity*)m_PTarget)->GetSpeed();
     }
 
     // Lets not check mob things on non mobs
     if (m_PTarget->objtype == TYPE_MOB)
     {
-        if (baseSpeed == 0 && (m_roamFlags & ROAMFLAG_WORM))
+        if (realSpeed == 0 && (m_roamFlags & ROAMFLAG_WORM))
         {
-            baseSpeed = 20;
-        }
-        // using 'else if' so we don't mess with worm speed.
-        else if (m_PTarget->animation == ANIMATION_ATTACK)
-        {
-            baseSpeed = baseSpeed + map_config.mob_speed_mod;
+            realSpeed = 20;
         }
     }
 
-    return baseSpeed;
+    return realSpeed;
 }
 
 bool CPathFind::IsFollowingPath()

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -39,8 +39,8 @@ CBaseEntity::CBaseEntity()
     memset(&loc, 0, sizeof(loc));
     animation    = ANIMATION_NONE;
     animationsub = 0;
-    speed        = 50 + map_config.speed_mod;
-    speedsub     = 50 + map_config.speed_mod;
+    speed        = 50;
+    speedsub     = 50;
     namevis      = 0;
     allegiance   = ALLEGIANCE_TYPE::MOB;
     updatemask   = 0;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -221,7 +221,22 @@ int32 CBattleEntity::GetMaxMP() const
 
 uint8 CBattleEntity::GetSpeed()
 {
-    int16 startingSpeed = isMounted() ? 40 + map_config.mount_speed_mod : speed;
+    int8 bonus = 0;
+    // NPC's don't get a bonus. Just players, mobs, pets..
+
+    // Mobs get their speed boost while agro'd/engaged
+    if (objtype == TYPE_MOB && animation == ANIMATION_ATTACK)
+    {
+        bonus = map_config.mob_speed_mod;
+        // ShowDebug("mob speed bonus: '%i' \n", bonus);
+    }
+    // Pets share the owners map_config.
+    else if (objtype == TYPE_PC || objtype == TYPE_PET)
+    {
+        bonus = map_config.speed_mod;
+    }
+
+    int16 startingSpeed = isMounted() ? 40 + map_config.mount_speed_mod : speed + bonus;
 
     // Mod::MOVE (169)
     // Mod::MOUNT_MOVE (972)

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -66,9 +66,9 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
         ref<uint8>(0x38) |= 0x08; // New player ?
     }
 
-    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // + управляем ростом: 0x02 - 0; 0x08 - 1; 0x10 - 2;
+    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // + model sizing : 0x02 - 0; 0x08 - 1; 0x10 - 2;
     ref<uint8>(0x2C) = PChar->GetSpeed();
-    ref<uint16>(0x2E) |= PChar->speedsub << 1;
+    ref<uint16>(0x2E) |= PChar->speedsub << 1; // Not sure about this, it was a work around when we set speedsub incorrectly..
     ref<uint8>(0x30) = PChar->m_event.EventID != -1 ? ANIMATION_EVENT : PChar->animation;
 
     CItemLinkshell* linkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Gravity is modifier based, so I can't cut off people from using mods on mob speed when they should not without breaking weight effects. As a reminder, monster and NPC base speeds should be set in the sql and not via mod MOVE in scripts or mod tables (lookin at you, former bugs with cactrot repido overflowing the int)

Relocated where confs are added in. I tested thoroughly, and these work though when you try to print it will keep showing the base speed. This is due to some missing/incorrect packet info, which also causes the chocobo speed to be reported as your players speed.

Also: retail does not increase the speedsub when movement speed goes up. I have checked this very very thoroughly, and it remain 50 no matter what bonus you put on the player. I checked to see if this made any visual difference in game at all and found it did not. I have removed our adding the conf to it accordingly. It seems fine afterwards but I left a comment in the packet where we previously had to make changes to accommodate it.