### PR TITLE
Time adjustments

### DIFF
--- a/scripts/globals/common.lua
+++ b/scripts/globals/common.lua
@@ -71,18 +71,9 @@ end
 -----------------------------------
 
 function getConquestTally()
-    -- Get time into a handy dandy table
-    local weekDayNumber = tonumber(os.date("%w"))
-    local daysToTally = 0
-    -- LUA is Sun -> Sat, conquest is Mon -> Sun, so adjustments via conditional are needed.
-    -- If today is Sunday (0), no additional days are necessary, so keep the 0.
-    -- Ex: Friday = 5, 7 - 5 = 2 days to add, all of Saturday and Sunday.
-    if weekDayNumber > 0 then
-        daysToTally = 7 - weekDayNumber
-    end
-
-    -- Midnight + daysToTally * a day worth of seconds.
-    return getMidnight() + daysToTally * 86400
+    local lastTally = (JstWeekday() + 6) % 7
+    local daysToTally = 6 - lastTally
+    return getMidnight() + (daysToTally * (60 * 60 * 24))
 end
 
 -----------------------------------

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kaduru-Haiduru.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kaduru-Haiduru.lua
@@ -11,11 +11,10 @@ local function canUse_KaduruHaiduru_Service(player)
     local caughtUsingShihuDanhuDate = player:getCharVar("Kaduru_ShihuDanhu_date")
     local shihuDanhuEncounters = player:getCharVar("ShihuDanhu_Encounters")
     local shihuDanhuDate = player:getCharVar("ShihuDanhu_TP_date")
-    local currentDate = os.date("%j")
 
     -- Kaduru-Haiduru can be used unless the following are true.
-    if (currentDate - shihuDanhuDate < 1 and shihuDanhuEncounters > 1) or
-        (currentDate - caughtUsingShihuDanhuDate < 1) then
+    if (shihuDanhuEncounters > 1 and os.time() < shihuDanhuDate) or
+        (os.time() < caughtUsingShihuDanhuDate) then
         return false
     end
     return true
@@ -25,13 +24,12 @@ entity.onTrigger = function(player, npc)
     local caughtUsingShihuDanhuDate = player:getCharVar("Kaduru_ShihuDanhu_date")
     local shihuDanhuDate = player:getCharVar("ShihuDanhu_TP_date")
     local timesUsed = player:getCharVar("Kaduru_TimesUsed")
-    local currentDate = os.date("%j")
 
     if canUse_KaduruHaiduru_Service(player) then
         player:startEvent(151, 0, 0, timesUsed, 0, 0, 0, 0, 0, 0)
     else
         if caughtUsingShihuDanhuDate == 0 then
-            player:setCharVar("Kaduru_ShihuDanhu_date", os.date("%j"))
+            player:setCharVar("Kaduru_ShihuDanhu_date", getVanaMidnight())
             player:setCharVar("Kaduru_TimesUsed", 0)
         end
         player:startEvent(153, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -61,7 +59,7 @@ entity.onTrade = function(player, npc, trade)
         end
     else
         if caughtUsingShihuDanhuDate == 0 then
-            player:setCharVar("Kaduru_ShihuDanhu_date", os.date("%j"))
+            player:setCharVar("Kaduru_ShihuDanhu_date", getVanaMidnight())
             player:setCharVar("Kaduru_TimesUsed", 0)
         end
         player:startEvent(155, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Naja_Salaheem.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Naja_Salaheem.lua
@@ -21,8 +21,6 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local TOAUM3_DAY = player:getCharVar("TOAUM3_STARTDAY")
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local needToZone = player:needToZone()
 
     if (player:getCharVar("AssaultPromotion") >= 25 and player:hasKeyItem(tpz.ki.PFC_WILDCAT_BADGE) == false and player:getCharVar("PromotionPFC") == 0) then
@@ -35,7 +33,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(3002, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.PRESIDENT_SALAHEEM and player:getCharVar("AhtUrganStatus") == 1) then
         player:startEvent(73, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.PRESIDENT_SALAHEEM and player:getCharVar("AhtUrganStatus") == 2 and TOAUM3_DAY ~= realday and needToZone == false) then
+    elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.PRESIDENT_SALAHEEM and player:getCharVar("AhtUrganStatus") == 2 and needToZone == false) then
         player:startEvent(3020, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.KNIGHT_OF_GOLD and player:getCharVar("AhtUrganStatus") == 0) then
         player:startEvent(3021, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -109,7 +107,6 @@ end
 entity.onEventFinish = function(player, csid, option)
     if (csid == 73) then
         player:setCharVar("AhtUrganStatus", 2)
-        player:setCharVar("TOAUM3_DAY", os.date("%j")) -- %M for next minute, %j for next day
     elseif (csid == 3002) then
         player:setCharVar("AhtUrganStatus", 0)
         player:completeMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.IMMORTAL_SENTRIES)
@@ -122,7 +119,6 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("AhtUrganStatus", 0)
         player:completeMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.PRESIDENT_SALAHEEM)
         player:addMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.KNIGHT_OF_GOLD)
-        player:setCharVar("TOAUM3_DAY", 0)
     elseif (csid == 3028) then
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 2185)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Rytaal.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Rytaal.lua
@@ -17,10 +17,9 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local currentday = tonumber(os.date("%j"))
     local lastIDtag = player:getCharVar("LAST_IMPERIAL_TAG")
     local tagCount = player:getCurrency("id_tags")
-    local diffday = currentday - lastIDtag
+    local diffday = math.floor((os.time() - lastIDtag) / (60 * 60 * 24))
     local currentAssault = player:getCurrentAssault()
     local haveimperialIDtag
 
@@ -41,14 +40,14 @@ entity.onTrigger = function(player, npc)
         if lastIDtag == 0 then -- first time you get the tag
             tagCount = 1
             player:setCurrency("id_tags", tagCount)
-            player:setCharVar("LAST_IMPERIAL_TAG", currentday)
+            player:setCharVar("LAST_IMPERIAL_TAG", os.time())
         elseif diffday > 0 then
             tagCount = tagCount + diffday
             if tagCount > 3 then -- store 3 TAG max
                 tagCount = 3
             end
             player:setCurrency("id_tags", tagCount)
-            player:setCharVar("LAST_IMPERIAL_TAG", currentday)
+            player:setCharVar("LAST_IMPERIAL_TAG", os.time())
         end
 
         if player:hasKeyItem(tpz.ki.IMPERIAL_ARMY_ID_TAG) then

--- a/scripts/zones/Al_Zahbi/npcs/Shihu-Danhu.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Shihu-Danhu.lua
@@ -27,7 +27,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 103 and option == 1 then
         local shihuDanhuEncounters = player:getCharVar("ShihuDanhu_Encounters")
         -- If you use TP, you need to wait 1 real day for using Kaduru TP
-        player:setCharVar("ShihuDanhu_TP_date", os.date("%j"))
+        player:setCharVar("ShihuDanhu_TP_date", getVanaMidnight())
         -- Update total number of Shihu-Danhu encounters.
         player:setCharVar("ShihuDanhu_Encounters", (shihuDanhuEncounters + 1))
 

--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -202,7 +202,7 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("MissionStatus", 2)
     elseif (csid == 102) then
         finishMissionTimeline(player, 3, csid, option)
-        player:setCharVar("Wait1DayM8-1_date", os.date("%j"))
+        player:setCharVar("Wait1DayM8-1_date", os.time() + 60)
     elseif (csid == 564 and option == 1) then
         player:completeMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.CONFESSIONS_OF_ROYALTY)
         player:addMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.EASTERLY_WINDS)

--- a/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeFire_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeFire_date", 0)
         player:addFame(KAZHAM, 30)
         player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE)
     end

--- a/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeIce_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeIce_date", 0)
         player:addFame(SANDORIA, 30)
         player:completeQuest(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE)
     end

--- a/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WIND) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeWind_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeWind_date", 0)
         player:addFame(RABAO, 30)
         player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WIND)
     end

--- a/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeLightning_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeLightning_date", 0)
         player:addFame(WINDURST, 30)
         player:completeQuest(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING)
     end

--- a/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeWater_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeWater_date", 0)
         player:addFame(NORG, 30)
         player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER)
     end

--- a/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
@@ -24,7 +24,6 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local arg8 = (player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH) == QUEST_COMPLETED) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == tpz.battlefield.leaveCode.LOST then
-        player:setCharVar("TrialSizeEarth_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
         player:startEvent(32002)
     end
 end
@@ -42,7 +41,6 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addItem(4181) -- Scroll of instant warp
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setCharVar("TrialSizeEarth_date", 0)
         player:addFame(BASTOK, 30)
         player:completeQuest(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH)
     end

--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -60,7 +60,7 @@ battlefield_object.onEventFinish = function(player, csid, option)
         if player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 2 then
             player:addKeyItem(tpz.ki.TEAR_OF_ALTANA)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.TEAR_OF_ALTANA)
-            player:setCharVar("Promathia_kill_day", tonumber(os.date("%j")))
+            player:setCharVar("Promathia_kill_day", getMidnight())
             player:setCharVar("PromathiaStatus", 3)
         end
     end

--- a/scripts/zones/FeiYin/npcs/Seed_Afterglow.lua
+++ b/scripts/zones/FeiYin/npcs/Seed_Afterglow.lua
@@ -27,7 +27,6 @@ end
 entity.onTrigger = function(player, npc)
     local offset        = npc:getID() - ID.npc.AFTERGRLOW_OFFSET
     local ACP           = player:getCurrentMission(ACP)
-    local currentDay    = tonumber(os.date("%j"))
     local needToZone    = player:needToZone()
     local progressMask  = player:getCharVar("SEED_AFTERGLOW_MASK")
     local intensity     = player:getCharVar("SEED_AFTERGLOW_INTENSITY")
@@ -36,8 +35,8 @@ entity.onTrigger = function(player, npc)
         player:hasKeyItem(tpz.ki.MARK_OF_SEED) or
         player:hasKeyItem(tpz.ki.AZURE_KEY) or
         player:hasKeyItem(tpz.ki.IVORY_KEY) or
-        CurrentDay == player:getCharVar("LastAzureKey") or
-        CurrentDay == player:getCharVar("LastIvoryKey") or
+        os.time() < player:getCharVar("LastAzureKey") or
+        os.time() < player:getCharVar("LastIvoryKey") or
         ACP < tpz.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_II
     ) then
         player:messageSpecial(ID.text.SOFTLY_SHIMMERING_LIGHT)

--- a/scripts/zones/Hall_of_Transference/Zone.lua
+++ b/scripts/zones/Hall_of_Transference/Zone.lua
@@ -71,7 +71,7 @@ zone_object.onRegionEnter = function(player, region)
         end,
         [5] = function (x)
             if player:getCharVar("MeaChipRegistration") == 1 then
-                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpMea") ~= tonumber(os.date("%j")) then -- 5% Chance chip breaks
+                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpMea") < os.time() then -- 5% Chance chip breaks
                     player:startEvent(161) -- To Sky
                 else
                     player:startEvent(169) -- Chip Breaks!
@@ -82,7 +82,7 @@ zone_object.onRegionEnter = function(player, region)
         end,
         [6] = function (x)
             if player:getCharVar("HollaChipRegistration") == 1 then
-                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpHolla") ~= tonumber(os.date("%j")) then -- 5% Chance chip breaks
+                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpHolla") < os.time() then -- 5% Chance chip breaks
                     player:startEvent(161) -- To Sky
                 else
                     player:startEvent(170) -- Chip Breaks!
@@ -93,7 +93,7 @@ zone_object.onRegionEnter = function(player, region)
         end,
         [7] = function (x)
             if player:getCharVar("DemChipRegistration") == 1 then
-                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpDem") ~= tonumber(os.date("%j")) then -- 5% Chance chip breaks
+                if math.random(1, 100) <= 95 or player:getCharVar("LastSkyWarpDem") < os.time() then -- 5% Chance chip breaks
                     player:startEvent(161) -- To Sky
                 else
                     player:startEvent(171) -- Chip Breaks!
@@ -133,11 +133,11 @@ zone_object.onEventFinish = function(player, csid, option)
         local prevZone = player:getPreviousZone()
 
         if prevZone == tpz.zone.LA_THEINE_PLATEAU then
-            player:setCharVar("LastSkyWarpHolla", tonumber(os.date("%j")))
+            player:setCharVar("LastSkyWarpHolla", getMidnight())
         elseif prevZone == tpz.zone.KONSCHTAT_HIGHLANDS then
-            player:setCharVar("LastSkyWarpDem", tonumber(os.date("%j")))
+            player:setCharVar("LastSkyWarpDem", getMidnight())
         elseif prevZone == tpz.zone.TAHRONGI_CANYON then
-            player:setCharVar("LastSkyWarpMea", tonumber(os.date("%j")))
+            player:setCharVar("LastSkyWarpMea", getMidnight())
         end
 
         tpz.teleport.to(player, tpz.teleport.id.SKY)

--- a/scripts/zones/Kazham/npcs/Dodmos.lua
+++ b/scripts/zones/Kazham/npcs/Dodmos.lua
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
 
         if (FireFork == true) then
             player:startEvent(272) --Dialogue given to remind player to be prepared
-        elseif (FireFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeFire_date")) then
+        else
             player:startEvent(290, 0, 1544, 0, 20) --Need another mini tuning fork
         end
     elseif (TrialSizeFire == QUEST_COMPLETED) then
@@ -49,7 +49,6 @@ entity.onEventFinish = function(player, csid, option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1544) --Mini tuning fork
         else
-            player:setCharVar("TrialSizeFire_date", 0)
             player:addQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE)
             player:addItem(1544)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1544)

--- a/scripts/zones/Kazham/npcs/Ronta-Onta.lua
+++ b/scripts/zones/Kazham/npcs/Ronta-Onta.lua
@@ -19,9 +19,8 @@ entity.onTrigger = function(player, npc)
 
     TrialByFire = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_FIRE)
     WhisperOfFlames = player:hasKeyItem(tpz.ki.WHISPER_OF_FLAMES)
-    realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
 
-    if ((TrialByFire == QUEST_AVAILABLE and player:getFameLevel(KAZHAM) >= 6) or (TrialByFire == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByFire_date"))) then
+    if ((TrialByFire == QUEST_AVAILABLE and player:getFameLevel(KAZHAM) >= 6) or (TrialByFire == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByFire_date"))) then
         player:startEvent(270, 0, tpz.ki.TUNING_FORK_OF_FIRE) -- Start and restart quest "Trial by Fire"
     elseif (TrialByFire == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_FIRE) == false and WhisperOfFlames == false) then
         player:startEvent(285, 0, tpz.ki.TUNING_FORK_OF_FIRE) -- Defeat against Ifrit : Need new Fork
@@ -82,7 +81,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_FIRE)
             player:delKeyItem(tpz.ki.WHISPER_OF_FLAMES)
-            player:setCharVar("TrialByFire_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByFire_date", getMidnight())
             player:addFame(KAZHAM, 30)
             player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_FIRE)
         end

--- a/scripts/zones/Metalworks/npcs/Cid.lua
+++ b/scripts/zones/Metalworks/npcs/Cid.lua
@@ -52,7 +52,12 @@ entity.onTrigger = function(player, npc)
 
     if wsQuestEvent ~= nil then
         player:startEvent(wsQuestEvent)
-    elseif (currentCOPMission == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day")<os.time() and player:getCharVar("COP_tenzen_story")== 0 ) then
+    elseif
+        currentCOPMission == tpz.mission.id.cop.DAWN and
+        player:getCharVar("PromathiaStatus") == 3 and
+        player:getCharVar("Promathia_kill_day") < os.time() and
+        player:getCharVar("COP_tenzen_story") == 0
+    then
         player:startEvent(897) -- COP event
     elseif (currentCOPMission == tpz.mission.id.cop.CALM_BEFORE_THE_STORM and player:hasKeyItem(tpz.ki.LETTERS_FROM_ULMIA_AND_PRISHE) == false and player:getCharVar("COP_Dalham_KILL") == 2 and player:getCharVar("COP_Boggelmann_KILL") == 2 and player:getCharVar("Cryptonberry_Executor_KILL")==2) then
         player:startEvent(892) -- COP event

--- a/scripts/zones/Metalworks/npcs/Cid.lua
+++ b/scripts/zones/Metalworks/npcs/Cid.lua
@@ -41,7 +41,6 @@ end
 
 entity.onTrigger = function(player, npc)
     local wsQuestEvent = tpz.wsquest.getTriggerEvent(wsQuest, player)
-    local currentday = tonumber(os.date("%j"))
     local CidsSecret = player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.CID_S_SECRET)
     local LetterKeyItem = player:hasKeyItem(tpz.ki.UNFINISHED_LETTER)
     local currentMission = player:getCurrentMission(BASTOK)
@@ -53,7 +52,7 @@ entity.onTrigger = function(player, npc)
 
     if wsQuestEvent ~= nil then
         player:startEvent(wsQuestEvent)
-    elseif (currentCOPMission == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day")~=currentday and player:getCharVar("COP_tenzen_story")== 0 ) then
+    elseif (currentCOPMission == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day")<os.time() and player:getCharVar("COP_tenzen_story")== 0 ) then
         player:startEvent(897) -- COP event
     elseif (currentCOPMission == tpz.mission.id.cop.CALM_BEFORE_THE_STORM and player:hasKeyItem(tpz.ki.LETTERS_FROM_ULMIA_AND_PRISHE) == false and player:getCharVar("COP_Dalham_KILL") == 2 and player:getCharVar("COP_Boggelmann_KILL") == 2 and player:getCharVar("Cryptonberry_Executor_KILL")==2) then
         player:startEvent(892) -- COP event

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -31,7 +31,6 @@ end
 
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
-    local currentday = tonumber(os.date("%j"))
 
     if player:getCurrentMission(ROV) == tpz.mission.id.rov.RESONACE and player:getCharVar("RhapsodiesStatus") == 0 then
         cs = 368
@@ -46,7 +45,7 @@ zone_object.onZoneIn = function(player, prevZone)
         end
     end
 
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") ~= currentday and player:getCharVar("COP_shikarees_story")== 0 then
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_shikarees_story")== 0 then
         cs = 322
     end
 

--- a/scripts/zones/Mhaura/npcs/Lacia.lua
+++ b/scripts/zones/Mhaura/npcs/Lacia.lua
@@ -2,7 +2,6 @@
 -- Area: Mhaura
 --  NPC: Lacia
 -- Starts Quest: Trial Size Trial By Lightning
---  The "TrialSizeLightning_date" still needs to be set at the BCNM/Mob level to reflect defeat by the Avatar
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -29,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         if (LightningFork == true) then
             player:startEvent(10018) --Dialogue given to remind player to be prepared
-        elseif (LightningFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeLightning_date")) then
+        else
             player:startEvent(10029, 0, 1548, 5, 20) --Need another mini tuning fork
         end
     elseif (TrialSizeLightning == QUEST_COMPLETED) then
@@ -47,7 +46,6 @@ entity.onEventFinish = function(player, csid, option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1548) --Mini tuning fork
         else
-            player:setCharVar("TrialSizeLightning_date", 0)
             player:addQuest(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING)
             player:addItem(1548)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1548)

--- a/scripts/zones/Mhaura/npcs/Ripapa.lua
+++ b/scripts/zones/Mhaura/npcs/Ripapa.lua
@@ -20,7 +20,6 @@ entity.onTrigger = function(player, npc)
 
     local TrialByLightning = player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.TRIAL_BY_LIGHTNING)
     local WhisperOfStorms = player:hasKeyItem(tpz.ki.WHISPER_OF_STORMS)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local CarbuncleDebacle = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
     local CarbuncleDebacleProgress = player:getCharVar("CarbuncleDebacleProgress")
 
@@ -32,7 +31,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(10023, 0, 1172, 0, 0, 0, 0, 0, 0) -- "lost the pendulum?"
     -----------------------------------
     -- Trial by Lightning
-    elseif ((TrialByLightning == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 6) or (TrialByLightning == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByLightning_date"))) then
+    elseif ((TrialByLightning == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 6) or (TrialByLightning == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByLightning_date"))) then
         player:startEvent(10016, 0, tpz.ki.TUNING_FORK_OF_LIGHTNING) -- Start and restart quest "Trial by Lightning"
     elseif (TrialByLightning == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_LIGHTNING) == false and WhisperOfStorms == false) then
         player:startEvent(10024, 0, tpz.ki.TUNING_FORK_OF_LIGHTNING) -- Defeat against Ramuh : Need new Fork
@@ -93,7 +92,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_LIGHTNING)
             player:delKeyItem(tpz.ki.WHISPER_OF_STORMS) --Whisper of Storms, as a trade for the above rewards
-            player:setCharVar("TrialByLightning_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByLightning_date", getMidnight())
             player:addFame(MHAURA, 30)
             player:completeQuest(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.TRIAL_BY_LIGHTNING)
         end

--- a/scripts/zones/Norg/npcs/Edal-Tahdal.lua
+++ b/scripts/zones/Norg/npcs/Edal-Tahdal.lua
@@ -20,9 +20,8 @@ entity.onTrigger = function(player, npc)
 
     local TrialByWater = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_WATER)
     local WhisperOfTides = player:hasKeyItem(tpz.ki.WHISPER_OF_TIDES)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
 
-    if ((TrialByWater == QUEST_AVAILABLE and player:getFameLevel(NORG) >= 4) or (TrialByWater == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByWater_date"))) then
+    if ((TrialByWater == QUEST_AVAILABLE and player:getFameLevel(NORG) >= 4) or (TrialByWater == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByWater_date"))) then
         player:startEvent(109, 0, tpz.ki.TUNING_FORK_OF_WATER) -- Start and restart quest "Trial by Water"
     elseif (TrialByWater == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_WATER) == false and WhisperOfTides == false) then
         player:startEvent(190, 0, tpz.ki.TUNING_FORK_OF_WATER) -- Defeat against Avatar : Need new Fork
@@ -83,7 +82,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_WATER)
             player:delKeyItem(tpz.ki.WHISPER_OF_TIDES) --Whisper of Tides, as a trade for the above rewards
-            player:setCharVar("TrialByWater_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByWater_date", getMidnight())
             player:addFame(NORG, 30)
             player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_WATER)
         end

--- a/scripts/zones/Norg/npcs/Mamaulabion.lua
+++ b/scripts/zones/Norg/npcs/Mamaulabion.lua
@@ -72,7 +72,6 @@ entity.onTrigger = function(player, npc)
     local mamaMia = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.MAMA_MIA)
     local moonlitPath = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.THE_MOONLIT_PATH)
     local evokersRing = player:hasItem(14625)
-    local realday = tonumber(os.date("%j"))  -- %M for next minute, %j for next day
     local questday = player:getCharVar("MamaMia_date")
 
     if mamaMia == QUEST_AVAILABLE and player:getFameLevel(NORG) >= 4 and moonlitPath == QUEST_COMPLETED then
@@ -82,9 +81,9 @@ entity.onTrigger = function(player, npc)
         local tradesMamaMia = player:getCharVar("tradesMamaMia")
 
         if utils.mask.isFull(tradesMamaMia, 7) then
-            if realday == questday then
+            if os.time() < questday then
                 player:startEvent(196) --need to wait longer for reward
-            elseif questday ~= 0 then
+            else
                 player:startEvent(197) --Reward
             end
         else
@@ -116,7 +115,7 @@ entity.onEventFinish = function(player, csid, option)
 
     elseif (csid == 195) then
         player:confirmTrade()
-        player:setCharVar("MamaMia_date", os.date("%j")) -- %M for next minute, %j for next day
+        player:setCharVar("MamaMia_date", getMidnight())
 
     elseif (csid == 197) then
         if (player:getFreeSlotsCount() == 0) then

--- a/scripts/zones/Norg/npcs/Verctissa.lua
+++ b/scripts/zones/Norg/npcs/Verctissa.lua
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
 
         if (WaterFork) then
             player:startEvent(111) --Dialogue given to remind player to be prepared
-        elseif (WaterFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeWater_date")) then
+        else
             player:startEvent(203, 0, 1549, 2, 20) --Need another mini tuning fork
         end
     elseif (TrialSizeWater == QUEST_COMPLETED) then
@@ -50,7 +50,6 @@ entity.onEventFinish = function(player, csid, option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1549) --Mini tuning fork
         else
-            player:setCharVar("TrialSizeWater_date", 0)
             player:addQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER)
             player:addItem(1549)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1549)

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -59,7 +59,7 @@ zone_object.onZoneIn = function(player, prevZone)
         cs = 1
     elseif currentMission == tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 4 then
         cs = 0
-    elseif player:hasCompletedMission(tpz.mission.log_id.SANDORIA, tpz.mission.id.sandoria.COMING_OF_AGE) and tonumber(os.date("%j")) == player:getCharVar("Wait1DayM8-1_date") then
+    elseif player:hasCompletedMission(tpz.mission.log_id.SANDORIA, tpz.mission.id.sandoria.COMING_OF_AGE) and os.time() > player:getCharVar("Wait1DayM8-1_date") then
         cs = 16
     end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
@@ -29,10 +29,8 @@ entity.onTrigger = function(player, npc)
 
         if (IceFork) then
             player:startEvent(708) --Dialogue given to remind player to be prepared
-        elseif (IceFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeIce_date")) then
-            player:startEvent(737, 0, 1545, 4, 20) -- Need another mini tuning fork
         else
-            player:startEvent(758) -- Standard dialog when you loose, and you don't wait 1 real day
+            player:startEvent(737, 0, 1545, 4, 20) -- Need another mini tuning fork
         end
     elseif (TrialSizeByIce == QUEST_COMPLETED) then
         player:startEvent(736) -- Defeated Avatar
@@ -51,7 +49,6 @@ entity.onEventFinish = function(player, csid, option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1545)
         else
-            player:setCharVar("TrialSizeIce_date", 0)
             player:addQuest(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE)
             player:addItem(1545)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1545)

--- a/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
@@ -14,14 +14,13 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local realday = tonumber(tostring(os.date("%Y")) .. os.date("%m") .. os.date("%d"))
     local TheMissingPiece = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.THE_MISSING_PIECE)
 
     if (TheMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TABLET_OF_ANCIENT_MAGIC) and player:hasKeyItem(tpz.ki.LETTER_FROM_ALFESAR)) then
         player:startEvent(703) -- Continuing the Quest
-    elseif (TheMissingPiece == QUEST_ACCEPTED and realday < player:getCharVar("TheMissingPiece_date")) then
+    elseif (TheMissingPiece == QUEST_ACCEPTED and os.time() < player:getCharVar("TheMissingPiece_date")) then
         player:startEvent(704) -- didn't wait a day yet
-    elseif (TheMissingPiece == QUEST_ACCEPTED and realday >= player:getCharVar("TheMissingPiece_date")) then
+    elseif (TheMissingPiece == QUEST_ACCEPTED and os.time() >= player:getCharVar("TheMissingPiece_date")) then
         player:startEvent(705) -- Quest Completed
     else
         player:startEvent(702) -- standard dialogue
@@ -35,7 +34,7 @@ end
 entity.onEventFinish = function(player, csid, option)
 
     if (csid == 703) then
-        player:setCharVar("TheMissingPiece_date", tostring(os.date("%Y")) .. os.date("%m") .. os.date("%d") + 1)
+        player:setCharVar("TheMissingPiece_date", os.time() + 60)
         player:addTitle(tpz.title.ACQUIRER_OF_ANCIENT_ARCANUM)
         player:delKeyItem(tpz.ki.TABLET_OF_ANCIENT_MAGIC)
         player:delKeyItem(tpz.ki.LETTER_FROM_ALFESAR)

--- a/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
@@ -20,7 +20,6 @@ entity.onTrigger = function(player, npc)
 
     local TrialByIce = player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.TRIAL_BY_ICE)
     local WhisperOfFrost = player:hasKeyItem(tpz.ki.WHISPER_OF_FROST)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local ClassReunion = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.CLASS_REUNION)
     local ClassReunionProgress = player:getCharVar("ClassReunionProgress")
 
@@ -31,7 +30,7 @@ entity.onTrigger = function(player, npc)
     elseif (ClassReunion == 1 and ClassReunionProgress == 5 and player:hasItem(1171) == false) then
         player:startEvent(712, 0, 1171, 0, 0, 0, 0, 0, 0) -- lost the ice pendulum need another one
     -----------------------------------
-    elseif ((TrialByIce == QUEST_AVAILABLE and player:getFameLevel(SANDORIA) >= 6) or (TrialByIce == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByIce_date"))) then
+    elseif ((TrialByIce == QUEST_AVAILABLE and player:getFameLevel(SANDORIA) >= 6) or (TrialByIce == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByIce_date"))) then
         player:startEvent(706, 0, tpz.ki.TUNING_FORK_OF_ICE) -- Start and restart quest "Trial by ice"
     elseif (TrialByIce == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_ICE) == false and WhisperOfFrost == false) then
         player:startEvent(718, 0, tpz.ki.TUNING_FORK_OF_ICE) -- Defeat against Shiva : Need new Fork
@@ -92,7 +91,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_ICE)
             player:delKeyItem(tpz.ki.WHISPER_OF_FROST) --Whisper of Frost, as a trade for the above rewards
-            player:setCharVar("TrialByIce_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByIce_date", getMidnight())
             player:addFame(SANDORIA, 30)
             player:completeQuest(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.TRIAL_BY_ICE)
         end

--- a/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
@@ -15,15 +15,14 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
-    starttime = player:getCharVar("MissionaryMan_date")
+    finishtime = player:getCharVar("MissionaryMan_date")
     MissionaryManVar = player:getCharVar("MissionaryManVar")
 
     if (MissionaryManVar == 2) then
         player:startEvent(698, 0, 1146) -- Start statue creation
-    elseif (MissionaryManVar == 3 and (starttime == realday or player:needToZone() == true)) then
+    elseif (MissionaryManVar == 3 and finishtime < os.time()) then
         player:startEvent(699) -- During statue creation
-    elseif (MissionaryManVar == 3 and starttime ~= realday and player:needToZone() == false) then
+    elseif (MissionaryManVar == 3 and finishtime >= os.time()) then
         player:startEvent(700) -- End of statue creation
     elseif (MissionaryManVar == 4) then
         player:startEvent(701) -- During quest (after creation)
@@ -38,7 +37,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if (csid == 698) then
         player:setCharVar("MissionaryManVar", 3)
-        player:setCharVar("MissionaryMan_date", os.date("%j")) -- %M for next minute, %j for next day
+        player:setCharVar("MissionaryMan_date", os.time() + 60)
         player:delKeyItem(tpz.ki.RAUTEINOTS_PARCEL)
         player:needToZone(true)
 

--- a/scripts/zones/Oldton_Movalpolos/Zone.lua
+++ b/scripts/zones/Oldton_Movalpolos/Zone.lua
@@ -22,7 +22,6 @@ zone_object.onConquestUpdate = function(zone, updatetype)
 end
 
 zone_object.onZoneIn = function(player, prevZone)
-    local currentday = tonumber(os.date("%j"))
     local louverancePath = player:getCharVar("COP_Louverance_s_Path")
     local cs = -1
 
@@ -32,7 +31,7 @@ zone_object.onZoneIn = function(player, prevZone)
 
     if player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and (louverancePath == 3 or louverancePath == 4) then
         cs = 1
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 3 and player:getCharVar("Promathia_kill_day") ~= currentday and player:getCharVar("COP_jabbos_story") == 0 then
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 3 and player:getCharVar("Promathia_kill_day") < os.date() and player:getCharVar("COP_jabbos_story") == 0 then
         cs = 57
     end
 

--- a/scripts/zones/Oldton_Movalpolos/Zone.lua
+++ b/scripts/zones/Oldton_Movalpolos/Zone.lua
@@ -31,7 +31,7 @@ zone_object.onZoneIn = function(player, prevZone)
 
     if player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and (louverancePath == 3 or louverancePath == 4) then
         cs = 1
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 3 and player:getCharVar("Promathia_kill_day") < os.date() and player:getCharVar("COP_jabbos_story") == 0 then
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_jabbos_story") == 0 then
         cs = 57
     end
 

--- a/scripts/zones/Port_Bastok/npcs/Ferrol.lua
+++ b/scripts/zones/Port_Bastok/npcs/Ferrol.lua
@@ -30,10 +30,8 @@ entity.onTrigger = function(player, npc)
 
         if (EarthFork) then
             player:startEvent(251) -- Dialogue given to remind player to be prepared
-        elseif (EarthFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeEarth_date")) then
-            player:startEvent(301, 0, 1547, 1, 20) -- Need another mini tuning fork
         else
-            player:startEvent(303) -- Standard dialog when you loose, and you don't wait 1 real day
+            player:startEvent(301, 0, 1547, 1, 20) -- Need another mini tuning fork
         end
     elseif (TrialSizeEarth == QUEST_COMPLETED) then
         player:startEvent(300) -- Defeated Avatar
@@ -52,7 +50,6 @@ entity.onEventFinish = function(player, csid, option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1547) --Mini tuning fork
         else
-            player:setCharVar("TrialSizeEarth_date", 0)
             player:addQuest(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH)
             player:addItem(1547)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1547)

--- a/scripts/zones/Port_Bastok/npcs/Juroro.lua
+++ b/scripts/zones/Port_Bastok/npcs/Juroro.lua
@@ -18,7 +18,6 @@ entity.onTrigger = function(player, npc)
 
     local TrialByEarth = player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.TRIAL_BY_EARTH)
     local WhisperOfTremors = player:hasKeyItem(tpz.ki.WHISPER_OF_TREMORS)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local ThePuppetMaster = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
     local ThePuppetMasterProgress = player:getCharVar("ThePuppetMasterProgress")
 
@@ -28,7 +27,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(257, 0, 1169, 0, 0, 0, 0, 0, 0)
     elseif (ThePuppetMaster == QUEST_ACCEPTED and ThePuppetMasterProgress == 3) then
         player:startEvent(258)
-    elseif ((TrialByEarth == QUEST_AVAILABLE and player:getFameLevel(BASTOK) >= 6) or (TrialByEarth == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByEarth_date"))) then
+    elseif ((TrialByEarth == QUEST_AVAILABLE and player:getFameLevel(BASTOK) >= 6) or (TrialByEarth == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByEarth_date"))) then
         player:startEvent(249, 0, tpz.ki.TUNING_FORK_OF_EARTH) -- Start and restart quest "Trial by Earth"
     elseif (TrialByEarth == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_EARTH) == false and WhisperOfTremors == false) then
         player:startEvent(284, 0, tpz.ki.TUNING_FORK_OF_EARTH) -- Defeat against Titan : Need new Fork
@@ -106,7 +105,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_EARTH)
             player:delKeyItem(tpz.ki.WHISPER_OF_TREMORS) --Whisper of Tremors, as a trade for the above rewards
-            player:setCharVar("TrialByEarth_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByEarth_date", getMidnight())
             player:addFame(BASTOK, 30)
             player:completeQuest(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.TRIAL_BY_EARTH)
         end

--- a/scripts/zones/Port_Bastok/npcs/Raifa.lua
+++ b/scripts/zones/Port_Bastok/npcs/Raifa.lua
@@ -18,7 +18,7 @@ end
 entity.onTrigger = function(player, npc)
     local ecoStatus = player:getCharVar("EcoStatus")
 
-    if ecoStatus == 0 and player:getFameLevel(BASTOK) >= 1 and player:getCharVar("EcoReset") ~= getConquestTally() then
+    if ecoStatus == 0 and player:getFameLevel(BASTOK) >= 1 and player:getCharVar("EcoReset") < os.time() then
         player:startEvent(278) -- Offer Eco-Warrior quest
     elseif ecoStatus == 101 then
         player:startEvent(280) -- Reminder dialogue to talk to Degga

--- a/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
@@ -315,11 +315,10 @@ entity.onTrade = function(player, npc, trade)
 
         -- found a match
         if tradedCombo > 0 then
-            local time = os.date("*t")
 
             player:confirmTrade()
             player:setCharVar("AFupgrade", tradedCombo)
-            player:setCharVar("AFupgradeDay", os.time() + (3600 - time.min * 60)) -- Current time + Remaining minutes in the hour in seconds (Day Change)
+            player:setCharVar("AFupgradeDay", getVanaMidnight()) -- Current time + Remaining minutes in the hour in seconds (Day Change)
             player:startEvent(312)
         end
     end

--- a/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
@@ -14,7 +14,6 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local now = tonumber(os.date("%j"))
     local count = trade:getItemCount()
     local sLux = trade:hasItemQty(2740, 1)
     local sLuna = trade:hasItemQty(2741, 1)
@@ -36,13 +35,13 @@ entity.onTrade = function(player, npc, trade)
     if (ENABLE_ACP == 0 and ENABLE_AMK == 0 and ENABLE_ASA ==0) then
         player:showText(npc, ID.text.GET_LOST)
     else    -- Crimson Key: Trade Seedspall's Lux, Luna, Astrum
-        if (ENABLE_ACP == 1 and sLux and sLuna and sAstrum and count == 3 and ACPm >= tpz.mission.id.acp.GATHERER_OF_LIGHT_I and CrimsonKey == false and now ~= LastCrimson) then -- and timer stuff here) then
+        if (ENABLE_ACP == 1 and sLux and sLuna and sAstrum and count == 3 and ACPm >= tpz.mission.id.acp.GATHERER_OF_LIGHT_I and CrimsonKey == false and os.time() > LastCrimson) then -- and timer stuff here) then
             player:tradeComplete()
             player:addKeyItem(tpz.ki.CRIMSON_KEY)
-            player:setCharVar("LastCrimsonKey", os.date("%j"))
+            player:setCharVar("LastCrimsonKey", getMidnight())
             player:messageSpecial(ID.text.DRYEYES_2)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.CRIMSON_KEY)
-        elseif (sLux and sLuna and sAstrum and count == 3 and (now == LastCrimson or CrimsonKey == true)) then
+        elseif (sLux and sLuna and sAstrum and count == 3 and (os.time() <= LastCrimson or CrimsonKey == true)) then
             player:messageSpecial(ID.text.DRYEYES_3, tpz.ki.CRIMSON_KEY)
         -- White Coral Key:
         -- elseif (ENABLE_AMK == 1 and
@@ -64,7 +63,6 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- uncommented printf till we have all optionIDs mapped out.
-    local now = tonumber(os.date("%j"))
     local ACPm = player:getCurrentMission(ACP)
     local AMKm = player:getCurrentMission(AMK)
     local ASAm = player:getCurrentMission(ASA)
@@ -78,15 +76,15 @@ entity.onEventFinish = function(player, csid, option)
         if (option == 1) then
             player:showText(player, ID.text.DRYEYES_1)
         elseif (option == 100) then
-            if (salad and juice and grub and ACPm >= tpz.mission.id.acp.GATHERER_OF_LIGHT_I and ViridianKey == false and now ~= LastViridian) then
+            if (salad and juice and grub and ACPm >= tpz.mission.id.acp.GATHERER_OF_LIGHT_I and ViridianKey == false and os.time() > LastViridian) then
                 player:addKeyItem(tpz.ki.VIRIDIAN_KEY)
                 player:delKeyItem(tpz.ki.BOWL_OF_BLAND_GOBLIN_SALAD)
                 player:delKeyItem(tpz.ki.JUG_OF_GREASY_GOBLIN_JUICE)
                 player:delKeyItem(tpz.ki.CHUNK_OF_SMOKED_GOBLIN_GRUB)
-                player:setCharVar("LastViridianKey", os.date("%j"))
+                player:setCharVar("LastViridianKey", getMidnight())
                 player:showText(player, ID.text.DRYEYES_2)
                 player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.VIRIDIAN_KEY)
-            elseif (now == LastViridian or ViridianKey == true) then
+            elseif (os.time() <= LastViridian or ViridianKey == true) then
                 player:messageSpecial(ID.text.DRYEYES_3, tpz.ki.VIRIDIAN_KEY)
             else
                 -- player:showText(player, ? )

--- a/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
+++ b/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
@@ -12,7 +12,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_3-taru_story")== 0 ) then
+    if
+        player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and
+        player:getCharVar("PromathiaStatus") == 3 and
+        player:getCharVar("Promathia_kill_day") < os.time() and
+        player:getCharVar("COP_3-taru_story") == 0
+    then
         player:startEvent(619)
     else
         player:startEvent(202)

--- a/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
+++ b/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
@@ -12,8 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local currentday = tonumber(os.date("%j"))
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") ~= currentday and player:getCharVar("COP_3-taru_story")== 0 ) then
+    if (player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_3-taru_story")== 0 ) then
         player:startEvent(619)
     else
         player:startEvent(202)

--- a/scripts/zones/QuBia_Arena/bcnms/those_who_lurk_in_shadows.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/those_who_lurk_in_shadows.lua
@@ -43,7 +43,7 @@ battlefield_object.onEventFinish = function(player, csid, option)
             player:addMission(tpz.mission.log_id.ACP, tpz.mission.id.acp.REMEMBER_ME_IN_YOUR_DREAMS)
         end
         if not player:hasKeyItem(tpz.ki.IVORY_KEY) and player:getCurrentMission(ACP) >= tpz.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_III then
-            player:setCharVar("LastIvoryKey", os.date("%j"))
+            player:setCharVar("LastIvoryKey", getMidnight())
             player:addKeyItem(tpz.ki.IVORY_KEY)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.IVORY_KEY)
         end

--- a/scripts/zones/Qufim_Island/npcs/qm3.lua
+++ b/scripts/zones/Qufim_Island/npcs/qm3.lua
@@ -20,7 +20,6 @@ end
 
 entity.onTrigger = function(player, npc)
     local missionACP = player:getCurrentMission(ACP)
-    local now = tonumber(os.date("%j"))
     local SR = player:hasKeyItem(tpz.ki.SEEDSPALL_ROSEUM)
     local SC = player:hasKeyItem(tpz.ki.SEEDSPALL_CAERULUM)
     local SV = player:hasKeyItem(tpz.ki.SEEDSPALL_VIRIDIS)
@@ -29,7 +28,7 @@ entity.onTrigger = function(player, npc)
     local lastViridian = player:getCharVar("LastViridianKey") -- When last Viridian key was obtained
 
     if ENABLE_ACP == 1 and not player:hasKeyItem(tpz.ki.AMBER_KEY) then
-        if missionACP == tpz.mission.id.acp.GATHERER_OF_LIGHT_I and SR and SC and SV and now ~= lastViridian then
+        if missionACP == tpz.mission.id.acp.GATHERER_OF_LIGHT_I and SR and SC and SV and os.time() > lastViridian then
             player:startEvent(32)
         elseif missionACP == tpz.mission.id.acp.GATHERER_OF_LIGHT_II and player:getCharVar("SEED_MANDY") == 0 then
             -- Spawn Seed mandragora's
@@ -39,12 +38,12 @@ entity.onTrigger = function(player, npc)
         elseif missionACP == tpz.mission.id.acp.GATHERER_OF_LIGHT_II and player:getCharVar("SEED_MANDY") == 1 then -- change SEED_MANDY var number later when battle actually works (intended purpose is to track number of slain mandies).
             player:setCharVar("SEED_MANDY", 0)
             player:startEvent(34)
-        -- elseif missionACP >= tpz.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_I and not amberKey and now ~= lastAmber and now ~= lastViridian and SR and SC and SV and player:getCharVar("SEED_MANDY") == 0) then
+        -- elseif missionACP >= tpz.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_I and not amberKey and os.time() > lastAmber and os.time() > lastViridian and SR and SC and SV and player:getCharVar("SEED_MANDY") == 0) then
             -- This is for repeats to get amber keys.
             -- Spawn Seed mandragora's with tpz.effect.CONFRONTATION for 30 min
         -- elseif SR and SC and SV and missionACP >= tpz.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_I and player:getCharVar("SEED_MANDY") == 1 then
             -- npcUtil.giveKeyItem(player, tpz.ki.AMBER_KEY)
-            -- player:setCharVar("LastAmberKey", os.date("%j"))
+            -- player:setCharVar("LastAmberKey", getMidnight())
             -- player:setCharVar("SEED_MANDY", 0)
             -- player:delKeyItem(tpz.ki.SEEDSPALL_ROSEUM)
             -- player:delKeyItem(tpz.ki.SEEDSPALL_CAERULUM)

--- a/scripts/zones/Rabao/npcs/Agado-Pugado.lua
+++ b/scripts/zones/Rabao/npcs/Agado-Pugado.lua
@@ -19,7 +19,6 @@ entity.onTrigger = function(player, npc)
 
     local TrialByWind = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_WIND)
     local WhisperOfGales = player:hasKeyItem(tpz.ki.WHISPER_OF_GALES)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local CarbuncleDebacle = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
     local CarbuncleDebacleProgress = player:getCharVar("CarbuncleDebacleProgress")
 
@@ -35,7 +34,7 @@ entity.onTrigger = function(player, npc)
         end
     -----------------------------------
     -- Trial by Wind
-    elseif ((TrialByWind == QUEST_AVAILABLE and player:getFameLevel(RABAO) >= 5) or (TrialByWind == QUEST_COMPLETED and realday ~= player:getCharVar("TrialByWind_date"))) then
+    elseif ((TrialByWind == QUEST_AVAILABLE and player:getFameLevel(RABAO) >= 5) or (TrialByWind == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByWind_date"))) then
         player:startEvent(66, 0, 331) -- Start and restart quest "Trial by Wind"
     elseif (TrialByWind == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.TUNING_FORK_OF_WIND) == false and WhisperOfGales == false) then
         player:startEvent(107, 0, 331) -- Defeat against Avatar : Need new Fork
@@ -94,7 +93,7 @@ entity.onEventFinish = function(player, csid, option)
             end
             player:addTitle(tpz.title.HEIR_OF_THE_GREAT_WIND)
             player:delKeyItem(tpz.ki.WHISPER_OF_GALES) --Whisper of Gales, as a trade for the above rewards
-            player:setCharVar("TrialByWind_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("TrialByWind_date", getMidnight())
             player:addFame(RABAO, 30)
             player:completeQuest(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.TRIAL_BY_WIND)
         end

--- a/scripts/zones/Rabao/npcs/Irmilant.lua
+++ b/scripts/zones/Rabao/npcs/Irmilant.lua
@@ -32,7 +32,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(77) --Offer the quest if the player has the broken rod
     elseif player:hasKeyItem(tpz.ki.SERPENT_RUMORS) == true and Indomitable == QUEST_AVAILABLE then
         player:startEvent(131) --Begins Indomitable Spirit
-    elseif indomitableTimer ~= 0 and indomitableTimer == getConquestTally() then
+    elseif indomitableTimer ~= 0 and indomitableTimer > os.time() then
         player:startEvent(133) --Asks the player to wait (next CQ tally)
     elseif indomitableTimer ~= 0 then
         player:startEvent(134) --Ends the Quest

--- a/scripts/zones/Rabao/npcs/Rahi_Fohlatti.lua
+++ b/scripts/zones/Rabao/npcs/Rahi_Fohlatti.lua
@@ -28,10 +28,8 @@ entity.onTrigger = function(player, npc)
 
         if (WindFork) then
             player:startEvent(68) -- Dialogue given to remind player to be prepared
-        elseif (WindFork == false and tonumber(os.date("%j")) ~= player:getCharVar("TrialSizeWind_date")) then
-            player:startEvent(112, 0, 1546, 3, 20) -- Need another mini tuning fork
         else
-            player:startEvent(114) -- Standard dialog when you loose, and you don't wait 1 real day
+            player:startEvent(112, 0, 1546, 3, 20) -- Need another mini tuning fork
         end
     elseif (TrialSizeWind == QUEST_COMPLETED) then
         player:startEvent(111) -- Defeated Avatar

--- a/scripts/zones/Selbina/npcs/Vuntar.lua
+++ b/scripts/zones/Selbina/npcs/Vuntar.lua
@@ -12,7 +12,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.CARGO) ~= QUEST_AVAILABLE then
-        if tonumber(os.date("%j")) ~= player:getCharVar("VuntarCanBuyItem_date") then
+        if os.time() > player:getCharVar("VuntarCanBuyItem_date") then
             if npcUtil.tradeHas(trade, 4529) then
                 player:startEvent(52, 1) -- Can Buy rolanberry (881 ce)
             elseif npcUtil.tradeHas(trade, 4530) then
@@ -43,7 +43,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 50 then
         player:addQuest(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.CARGO)
     elseif csid == 52 then
-        player:setCharVar("VuntarCanBuyItem_date", os.date("%j"))
+        player:setCharVar("VuntarCanBuyItem_date", getMidnight())
 
         if player:getQuestStatus(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.CARGO) == QUEST_ACCEPTED then
             player:completeQuest(tpz.quest.log_id.OTHER_AREAS, tpz.quest.id.otherAreas.CARGO)

--- a/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
@@ -14,12 +14,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local currentday = tonumber(os.date("%j"))
     if (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("EMERALD_WATERS_Status")==6 ) then
         player:startEvent(23)
     elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and player:getCharVar("COP_Ulmia_s_Path")== 0 ) then
         player:startEvent(22)
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") ~= currentday and player:getCharVar("COP_louverance_story")== 0 ) then
+    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus")==3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_louverance_story")== 0 ) then
         player:startEvent(757)
     else
         player:startEvent(580)

--- a/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
@@ -18,7 +18,7 @@ end
 entity.onTrigger = function(player, npc)
     local ecoStatus = player:getCharVar("EcoStatus")
 
-    if ecoStatus == 0 and player:getFameLevel(SANDORIA) >= 1 and player:getCharVar("EcoReset") ~= getConquestTally() then
+    if ecoStatus == 0 and player:getFameLevel(SANDORIA) >= 1 and player:getCharVar("EcoReset") < os.time() then
         player:startEvent(677) -- Offer Eco-Warrior quest
     elseif ecoStatus == 1 then
         player:startEvent(679) -- Reminder dialogue to talk to Rojaireaut

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
     elseif (beansAhoy == QUEST_ACCEPTED) then
         player:startEvent(335) -- Quest Active, NPC Repeats what he says but as normal 'text' instead of cutscene.
 
-    elseif (beansAhoy == QUEST_COMPLETED and getConquestTally() ~= player:getCharVar("BeansAhoy_ConquestWeek")) then
+    elseif (beansAhoy == QUEST_COMPLETED and os.time() > player:getCharVar("BeansAhoy_ConquestWeek")) then
         player:startEvent(342)
     elseif (beansAhoy == QUEST_COMPLETED) then
         player:startEvent(341)

--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -49,7 +49,6 @@ entity.onTrigger = function(player, npc)
     local OhbiruFood = player:getCharVar("Ohbiru_Food_var") -- Variable to track progress of Ohbiru-Dohbiru in Food for Thought
     local BlueRibbonBlues = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.BLUE_RIBBON_BLUES)
     local needZone = player:needToZone()
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local waking_dreams = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WAKING_DREAMS)
 
     -- Awakening of the Gods
@@ -65,7 +64,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(876)
 
     -- Waking Dreams
-    elseif (player:hasKeyItem(tpz.ki.VIAL_OF_DREAM_INCENSE)==false and ((player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.DARKNESS_NAMED) and  waking_dreams == QUEST_AVAILABLE ) or(waking_dreams  == QUEST_COMPLETED and realday ~= player:getCharVar("Darkness_Named_date")))) then
+    elseif (player:hasKeyItem(tpz.ki.VIAL_OF_DREAM_INCENSE)==false and ((player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.DARKNESS_NAMED) and  waking_dreams == QUEST_AVAILABLE ) or(waking_dreams  == QUEST_COMPLETED and os.time() > player:getCharVar("Darkness_Named_date")))) then
         player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WAKING_DREAMS)
         player:startEvent(918)--918
 
@@ -196,7 +195,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addGil(GIL_RATE*15000)
             player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*15000) -- Gil
             player:delKeyItem(tpz.ki.WHISPER_OF_DREAMS)
-            player:setCharVar("Darkness_Named_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("Darkness_Named_date", getMidnight())
             player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WAKING_DREAMS)
 
         elseif (option == 6 and player:hasSpell(304)==false) then
@@ -206,11 +205,11 @@ entity.onEventFinish = function(player, csid, option)
         end
         if (addspell==1) then
             player:delKeyItem(tpz.ki.WHISPER_OF_DREAMS)
-            player:setCharVar("Darkness_Named_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("Darkness_Named_date", getMidnight())
             player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WAKING_DREAMS)
         elseif (item > 0 and player:getFreeSlotsCount()~=0) then
             player:delKeyItem(tpz.ki.WHISPER_OF_DREAMS)
-            player:setCharVar("Darkness_Named_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("Darkness_Named_date", getMidnight())
             player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WAKING_DREAMS)
             player:addItem(item)
             player:messageSpecial(ID.text.ITEM_OBTAINED, item) -- Item

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -25,7 +25,6 @@ end
 
 entity.onTrigger = function(player, npc)
     local moonlitPath = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.THE_MOONLIT_PATH)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
     local MissionStatus = player:getCharVar("MissionStatus")
     local tuningIn = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.TUNING_IN)
     local tuningOut = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.TUNING_OUT)
@@ -110,7 +109,7 @@ entity.onTrigger = function(player, npc)
                 player:hasKeyItem(tpz.ki.FENRIR_WHISTLE) then availRewards = availRewards + 128; end -- Mount Pact
 
             player:startEvent(850, 0, 13399, 1208, 1125, availRewards, 18165, 13572)
-        elseif (realday ~= player:getCharVar("MoonlitPath_date")) then --24 hours have passed, flag a new fight
+        elseif (os.time() > player:getCharVar("MoonlitPath_date")) then --24 hours have passed, flag a new fight
             player:startEvent(848, 0, 1125, 334)
         end
     elseif tuningIn == QUEST_ACCEPTED then
@@ -179,7 +178,7 @@ entity.onEventFinish = function(player, csid, option)
         if (reward ~= nil) then
             player:addTitle(tpz.title.HEIR_OF_THE_NEW_MOON)
             player:delKeyItem(tpz.ki.WHISPER_OF_THE_MOON)
-            player:setCharVar("MoonlitPath_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("MoonlitPath_date", getMidnight())
             player:addFame(WINDURST, 30)
             player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.THE_MOONLIT_PATH)
         end
@@ -216,7 +215,7 @@ entity.onEventFinish = function(player, csid, option)
         if (reward ~= nil) then
             player:addTitle(tpz.title.HEIR_OF_THE_NEW_MOON)
             player:delKeyItem(tpz.ki.WHISPER_OF_THE_MOON)
-            player:setCharVar("MoonlitPath_date", os.date("%j")) -- %M for next minute, %j for next day
+            player:setCharVar("MoonlitPath_date", getMidnight())
             player:addFame(WINDURST, 30)
         end
 

--- a/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
@@ -19,7 +19,7 @@ end
 entity.onTrigger = function(player, npc)
     local ecoStatus = player:getCharVar("EcoStatus")
 
-    if ecoStatus == 0 and player:getFameLevel(WINDURST) >= 1 and player:getCharVar("EcoReset") ~= getConquestTally() then
+    if ecoStatus == 0 and player:getFameLevel(WINDURST) >= 1 and player:getCharVar("EcoReset") < os.time() then
         player:startEvent(818) -- Offer Eco-Warrior quest
     elseif ecoStatus == 201 then
         player:startEvent(820) -- Reminder dialogue to talk to Ahko

--- a/scripts/zones/Windurst_Woods/npcs/Kororo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kororo.lua
@@ -27,8 +27,8 @@ entity.onTrigger = function(player, npc)
     if C2000 == QUEST_COMPLETED and AGreetingCardian == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3 then
         player:startEvent(296) -- A Greeting Cardian quest start
     elseif AGreetingCardian == QUEST_ACCEPTED and AGCcs == 3 then
-        if player:needToZone() or tonumber(os.date("%j")) == AGCtime then
-            player:startEvent(277) -- standard dialog if JP midnight has not passed
+        if player:needToZone() or os.time() < AGCtime then
+            player:startEvent(277) -- standard dialog if 1 minute has not passed
         else
             player:startEvent(298) -- A Greeting Cardian part two
         end
@@ -53,7 +53,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 296 then
         player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
         player:setCharVar("AGreetingCardian_Event", 2)
-        player:setCharVar("AGreetingCardian_timer", os.date("%j"))
+        player:setCharVar("AGreetingCardian_timer", os.time() + 60)
         player:needToZone(true) -- wait one day and zone after next step
     elseif csid == 298 then
         player:setCharVar("AGreetingCardian_Event", 4)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -173,6 +173,7 @@ namespace luautils
         set_function("getMagianTrial", &luautils::GetMagianTrial);
         set_function("getMagianTrialsWithParent", &luautils::GetMagianTrialsWithParent);
         set_function("jstMidnight", &luautils::JstMidnight);
+        set_function("jstWeekday", &luautils::JstWeekday);
         set_function("vanadielTime", &luautils::VanadielTime);
         set_function("vanadielTOTD", &luautils::VanadielTOTD);
         set_function("vanadielHour", &luautils::VanadielHour);
@@ -902,6 +903,18 @@ namespace luautils
     {
         TracyZoneScoped;
         return CVanaTime::getInstance()->getJstMidnight();
+    }
+
+    /************************************************************************
+     *                                                                       *
+     * JstWeekday - Returns days since Sunday JST
+     *                                                                       *
+     ************************************************************************/
+
+    uint32 JstWeekday()
+    {
+        TracyZoneScoped;
+        return CVanaTime::getInstance()->getJstWeekDay();
     }
 
     /************************************************************************

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -152,6 +152,7 @@ namespace luautils
     auto   GetMagianTrial(sol::variadic_args va) -> sol::table;
     auto   GetMagianTrialsWithParent(int32 parentTrial) -> sol::table;
     uint32 JstMidnight();
+    uint32 JstWeekday();
     uint32 VanadielTime();          // Gets the current Vanadiel Time in timestamp format (SE epoch in earth seconds)
     uint8  VanadielTOTD();          // текущее игровое время суток
     uint32 VanadielHour();          // текущие Vanadiel часы


### PR DESCRIPTION
Fixed `getConquestTally` to give the correct timestamp and changed occurrences of `os.date` to the correct wait times for current retail. This means some stuff was changed to 60 seconds, some stuff was changed from "next day local time" to actual JP midnight, and other stuff with wait times was removed. Everything should be using a Unix timestamp, so shouldn't have any weird failures. Tested `getConquestTally` and the ROE 4-hour blocks.

Fixes #2532
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [ ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
