### PR TITLE
Dynamically change droplist content

### DIFF
--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -184,6 +184,9 @@ public:
 
     uint32 m_DropID; // dropid of items to be dropped. dropid in Database (mob_droplist)
 
+    // ItemID, <Droprate, DropType>
+    std::map<uint16, std::pair<uint16, uint8>> m_DropListModifications;
+
     uint8  m_minLevel; // lowest possible level of the mob
     uint8  m_maxLevel; // highest possible level of the mob
     uint32 HPmodifier; // HP in Database (mob_groups)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12133,7 +12133,10 @@ void CLuaBaseEntity::setDropID(uint32 dropID)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
 
-    static_cast<CMobEntity*>(m_PBaseEntity)->m_DropID = dropID;
+    auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
+
+    PMob->m_DropID = dropID;
+    PMob->m_DropListModifications.clear();
 }
 
 /************************************************************************
@@ -12272,6 +12275,25 @@ int16 CLuaBaseEntity::getTHlevel()
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
     return PMob->isDead() ? PMob->m_THLvl : PMob->PEnmityContainer->GetHighestTH();
+}
+
+/************************************************************************
+ *  Function: addDropListModification()
+ *  Purpose : Adds a modification to the drop list of this mob, to be applied just before loot is rolled.
+ *  Example : mob:addDropListModification(4112, 1000) -- Set drop rate of Potion to 100%
+ *  Notes   : Erased on death, once the modifications are applied.
+ *          : Modifications are cleared if the drop list is changed.
+ ************************************************************************/
+
+void CLuaBaseEntity::addDropListModification(uint16 id, uint16 newRate, sol::variadic_args va)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+    auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
+
+    uint8 dropType = va[0].get_type() == sol::type::number ? va[0].as<uint8>() : 0;
+
+    PMob->m_DropListModifications[id] = std::pair<uint16, uint8>(newRate, dropType);
 }
 
 //==========================================================//
@@ -12954,6 +12976,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getDespoilDebuff", CLuaBaseEntity::getDespoilDebuff);
     SOL_REGISTER("itemStolen", CLuaBaseEntity::itemStolen);
     SOL_REGISTER("getTHlevel", CLuaBaseEntity::getTHlevel);
+    SOL_REGISTER("addDropListModification", CLuaBaseEntity::addDropListModification);
+
     SOL_REGISTER("getPlayerRegionInZone", CLuaBaseEntity::getPlayerRegionInZone);
     SOL_REGISTER("updateToEntireZone", CLuaBaseEntity::updateToEntireZone);
 }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -737,6 +737,7 @@ public:
     uint16 getDespoilDebuff(uint16 itemID);                                              // gets the status effect id to apply to the mob on successful despoil
     bool   itemStolen();                                                                 // sets mob's ItemStolen var = true
     int16  getTHlevel();                                                                 // Returns the Monster's current Treasure Hunter Tier
+    void   addDropListModification(uint16 id, uint16 newRate, sol::variadic_args va);    // Adds a modification to the drop list of this mob, erased on death
 
     static void Register();
 };


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Previously, the drops from a mob are set using ONLY it's DropID: A lookup to a global drop list. 
If you wanted to change the drops a mob had, you either had to modify that global list (effecting anything else that uses that list), or you had to swap that mobs DropID for another one.

**The main changes in this PR:**
When it's time to roll loot, make a TEMPORARY copy of the drop list assigned to the mob.
Add a facility to add a list of droplist modifications that will be actioned just before the droplist is rolled on.

**Testing**
Added `mob:addDropListModification(4112, 1000)` to onMobDeath for birds in Sky.
They dropped a potion.
Remove and hot-reload.
They no longer drop potions.