### PR TITLE
Remove unrequired personal branding

### DIFF
--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -1,7 +1,4 @@
 ﻿/*
- * notoriety_container.cpp
- *      Author: zach2good | github.com/zach2good
- *
 ===========================================================================
   Copyright (c) 2020 Topaz Dev Teams
   This program is free software: you can redistribute it and/or modify

--- a/src/map/notoriety_container.h
+++ b/src/map/notoriety_container.h
@@ -1,7 +1,4 @@
 ﻿/*
- * notoriety_container.h
- *      Author: zach2good | github.com/zach2good
- *
 ===========================================================================
   Copyright (c) 2020 Topaz Dev Teams
   This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

This was added when we were trying to trap people with AGPL, and we're no longer trying to drive a big wedge down the middle of our code with two different licenses, so this can go ✂️ 

(making a PR because I'm quickly doing this through the web client)
