### PR TITLE
Third Eye and Utsusemi should not stack.

### DIFF
--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -17,8 +17,8 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
-		if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
-		effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else --Returns "no effect" message when Copy Image is active when Third Eye is used.
-		player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
-	end
+    if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
+        effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else          --Returns "no effect" message when Copy Image is active when Third Eye is used.
+        player:addStatusEffect(tpxz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
+    end
 end

--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -19,10 +19,6 @@ end
 function onUseAbility(player, target, ability)
     if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
         effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else          --Returns "no effect" message when Copy Image is active when Third Eye is used.
-<<<<<<< HEAD
         player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
-=======
-        player:addStatusEffect(tpxz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
->>>>>>> f99628915e1240c0d081120fe4aa33ac6e8daf45
     end
 end

--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -18,7 +18,8 @@ end
 
 function onUseAbility(player, target, ability)
     if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
-        effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else          --Returns "no effect" message when Copy Image is active when Third Eye is used.
+        effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) --Returns "no effect" message when Copy Image is active when Third Eye is used.
+    else
         player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
     end
 end

--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -17,5 +17,8 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
-    player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
+		if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
+		effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else --Returns "no effect" message when Copy Image is active when Third Eye is used.
+		player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
+	end
 end

--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -17,8 +17,8 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
-		if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
-		effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else --Returns "no effect" message when Copy Image is active when Third Eye is used.
-		player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
-	end
+    if (player:hasStatusEffect(tpz.effect.COPY_IMAGE)) then
+        effect:setMsg(tpz.msg.basic.JA_NO_EFFECT) else          --Returns "no effect" message when Copy Image is active when Third Eye is used.
+        player:addStatusEffect(tpz.effect.THIRD_EYE, 0, 0, 30) --power keeps track of procs
+    end
 end

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -11,11 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-<<<<<<< HEAD
     target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
-=======
-    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
->>>>>>> f99628915e1240c0d081120fe4aa33ac6e8daf45
     
 	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)
@@ -33,4 +29,3 @@ function onSpellCast(caster, target, spell)
 
     return tpz.effect.COPY_IMAGE
 end
-

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -5,13 +5,13 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster,target,spell)
+function onMagicCastingCheck(caster, target, spell)
     return 0
 end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
     
 	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)
@@ -29,3 +29,4 @@ function onSpellCast(caster, target, spell)
 
     return tpz.effect.COPY_IMAGE
 end
+

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -10,8 +10,11 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
+    if (target:hasStatusEffect(tpz.effect.THIRD_EYE)) then
+        target:delStatusEffect(tpz.effect.THIRD_EYE) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    end
+
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
     
 	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -5,13 +5,13 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster,target,spell)
+function onMagicCastingCheck(caster, target, spell)
     return 0
 end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
     
 	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -9,7 +9,7 @@ function onMagicCastingCheck(caster,target,spell)
     return 0
 end
 
-function onSpellCast(caster,target,spell)
+function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
 	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
     

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -5,14 +5,15 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster, target, spell)
+function onMagicCastingCheck(caster,target,spell)
     return 0
 end
 
-function onSpellCast(caster, target, spell)
+function onSpellCast(caster,target,spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-
-    -- Get extras shadows
+	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    
+	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)
     local icon = tpz.effect.COPY_IMAGE_3
     if (numShadows > 3) then

--- a/scripts/globals/spells/utsusemi_ichi.lua
+++ b/scripts/globals/spells/utsusemi_ichi.lua
@@ -11,7 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
     
 	-- Get extras shadows
     local numShadows = 3 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -11,7 +11,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 	
     -- Get extras shadows
     local numShadows = 3

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -10,8 +10,11 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
+    if (target:hasStatusEffect(tpz.effect.THIRD_EYE)) then
+        target:delStatusEffect(tpz.effect.THIRD_EYE) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    end
+
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 	
     -- Get extras shadows
     local numShadows = 3

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -5,13 +5,13 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster,target,spell)
+function onMagicCastingCheck(caster, target, spell)
     return 0
 end
 
-function onSpellCast(caster,target,spell)
+function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 	
     -- Get extras shadows
     local numShadows = 3

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -5,13 +5,13 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster,target,spell)
+function onMagicCastingCheck(caster, target, spell)
     return 0
 end
 
-function onSpellCast(caster,target,spell)
+function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 	
     -- Get extras shadows
     local numShadows = 3

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -11,11 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-<<<<<<< HEAD
     target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
-=======
-    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
->>>>>>> f99628915e1240c0d081120fe4aa33ac6e8daf45
 	
     -- Get extras shadows
     local numShadows = 3

--- a/scripts/globals/spells/utsusemi_ni.lua
+++ b/scripts/globals/spells/utsusemi_ni.lua
@@ -5,13 +5,14 @@ require("scripts/globals/status")
 require("scripts/globals/msg")
 -----------------------------------------
 
-function onMagicCastingCheck(caster, target, spell)
+function onMagicCastingCheck(caster,target,spell)
     return 0
 end
 
-function onSpellCast(caster, target, spell)
+function onSpellCast(caster,target,spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-
+	and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+	
     -- Get extras shadows
     local numShadows = 3
     local icon = tpz.effect.COPY_IMAGE_3

--- a/scripts/globals/spells/utsusemi_san.lua
+++ b/scripts/globals/spells/utsusemi_san.lua
@@ -11,6 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
+    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 
     -- Get extras shadows
     local numShadows = 5 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_san.lua
+++ b/scripts/globals/spells/utsusemi_san.lua
@@ -11,7 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 
     -- Get extras shadows
     local numShadows = 5 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_san.lua
+++ b/scripts/globals/spells/utsusemi_san.lua
@@ -11,11 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-<<<<<<< HEAD
     target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
-=======
-    and target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
->>>>>>> f99628915e1240c0d081120fe4aa33ac6e8daf45
 
     -- Get extras shadows
     local numShadows = 5 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_san.lua
+++ b/scripts/globals/spells/utsusemi_san.lua
@@ -10,8 +10,11 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
+    if (target:hasStatusEffect(tpz.effect.THIRD_EYE)) then
+        target:delStatusEffect(tpz.effect.THIRD_EYE) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    end
+
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 
     -- Get extras shadows
     local numShadows = 5 + target:getMod(tpz.mod.UTSUSEMI_BONUS)

--- a/scripts/globals/spells/utsusemi_san.lua
+++ b/scripts/globals/spells/utsusemi_san.lua
@@ -11,7 +11,7 @@ end
 
 function onSpellCast(caster, target, spell)
     local effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
-	target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
+    target:delStatusEffect(67) -- Third Eye and Utsusemi don't stack.  Utsusemi removes Third Eye.
 
     -- Get extras shadows
     local numShadows = 5 + target:getMod(tpz.mod.UTSUSEMI_BONUS)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

![image](https://user-images.githubusercontent.com/37130689/106616443-914ab400-653b-11eb-84a5-b9befb3eecb2.png)


Above image taken from retail.  These effects shouldn't stack.  Copy Image should wipe Third Eye, and Third Eye should have no effect when player is under the effect of Copy Image. 