### PR TITLE
[sol_refactor] Move function before onMobDeath

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Ruaern.lua
+++ b/scripts/zones/AlTaieu/mobs/Ruaern.lua
@@ -9,6 +9,12 @@ require("scripts/globals/missions")
 -----------------------------------
 local entity = {}
 
+local function clearTowerVars(player, towerNum)
+    player:setCharVar("Ru_aern_"..towerNum.."-1KILL", 0)
+    player:setCharVar("Ru_aern_"..towerNum.."-2KILL", 0)
+    player:setCharVar("Ru_aern_"..towerNum.."-3KILL", 0)
+end
+
 entity.onMobDeath = function(mob, player, isKiller)
 
     if (player:getCurrentMission(COP) == tpz.mission.id.cop.GARDEN_OF_ANTIQUITY and player:getCharVar("PromathiaStatus") < 3) then
@@ -46,12 +52,6 @@ entity.onMobDeath = function(mob, player, isKiller)
             clearTowerVars(player, 3)
         end
     end
-end
-
-local function clearTowerVars(player, towerNum)
-    player:setCharVar("Ru_aern_"..towerNum.."-1KILL", 0)
-    player:setCharVar("Ru_aern_"..towerNum.."-2KILL", 0)
-    player:setCharVar("Ru_aern_"..towerNum.."-3KILL", 0)
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
