### PR TITLE
use set constructor in common.lua

### DIFF
--- a/scripts/globals/abilities/pets/attachments/flame_holder.lua
+++ b/scripts/globals/abilities/pets/attachments/flame_holder.lua
@@ -1,23 +1,24 @@
 -----------------------------------
 -- Attachment: Flame Holder
 -----------------------------------
+require("scripts/globals/common")
 require("scripts/globals/status")
 -----------------------------------
 local attachment_object = {}
 
-local validskills = {
-    [1940] = true,
-    [1941] = true,
-    [1942] = true,
-    [1943] = true,
-    [2065] = true,
-    [2066] = true,
-    [2067] = true,
-    [2299] = true,
-    [2300] = true,
-    [2301] = true,
-    [2743] = true,
-    [2744] = true
+local validskills = set{
+    1940,
+    1941,
+    1942,
+    1943,
+    2065,
+    2066,
+    2067,
+    2299,
+    2300,
+    2301,
+    2743,
+    2744,
 }
 
 attachment_object.onEquip = function(pet)

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -3,9 +3,11 @@
 -----------------------------------
 require("scripts/globals/casket_loot")
 require("scripts/globals/settings")
+require("scripts/globals/common")
 require("scripts/globals/status")
 require("scripts/globals/msg")
 require("scripts/globals/roe")
+-----------------------------------
 
 -----------------------------------
 -- Notes:

--- a/scripts/globals/magianobjectives.lua
+++ b/scripts/globals/magianobjectives.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Magian Trial Objectives
 -----------------------------------
+require("scripts/globals/common")
+-----------------------------------
 
 -- This is a table of anon function for Magian Trial objectives/conditions.
 -- Keyed by trial ID, if they return true, the trials progress is incremented and saved.

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -1,9 +1,11 @@
 -----------------------------------
 -- Magian trials
 -----------------------------------
-require("scripts/globals/msg")
-require("scripts/globals/zone")
 require("scripts/globals/magianobjectives")
+require("scripts/globals/common")
+require("scripts/globals/zone")
+require("scripts/globals/msg")
+-----------------------------------
 
 tpz = tpz or {}
 tpz.magian = tpz.magian or {}

--- a/scripts/globals/rhapsodies.lua
+++ b/scripts/globals/rhapsodies.lua
@@ -1,5 +1,6 @@
 -----------------------------------
 require("scripts/globals/missions")
+require("scripts/globals/common")
 require("scripts/globals/status")
 -----------------------------------
 
@@ -24,15 +25,6 @@ tpz.rhapsodies.expansion =
     [tpz.rhapsodies.character.CAIT_SITH]  = WOTG,
     [tpz.rhapsodies.character.ARCIELA]    = SOA,
 }
-
--- ALERT, TODO, NOTE: To be removed when set constructor makes it into master!
-local set = function(list)
-    local set = {}
-    for _, item in pairs(list) do
-        set[item] = true
-    end
-    return set
-end
 
 tpz.rhapsodies.unavailability =
 {

--- a/scripts/zones/Aht_Urhgan_Whitegate/Shared.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Shared.lua
@@ -2,16 +2,11 @@
 -- Tables and Functions Used at Multiple Places within Aht Urgan Whitegate
 -----------------------------------
 require("scripts/globals/settings")
-
--- Lua Set Initializer http://www.lua.org/pil/11.5.html
-function Set (list)
-    local set = {}
-    for _, l in ipairs(list) do set[l] = true end
-    return set
-end
+require("scripts/globals/common")
+-----------------------------------
 
 -- Set of Royal Palace Approved Armor
-ROYAL_PALACE_ALLOWED_BODY_ARMORS = Set{
+local ROYAL_PALACE_ALLOWED_BODY_ARMORS = set{
     12548, -- Adaman Cuirass Lv. 73 WAR / PLD
     13746, -- Gem Cuirass Lv. 73 WAR / PLD
     13742, -- Aketon Lv. 60 MNK / WHM / RDM / THF / PLD / BST / BRD / DRG / SMN / BLU / COR / PUP / DNC


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Use set constructor that exists in https://github.com/topaz-next/topaz/blob/90d689e6bee5e37a74e7868593e134248f29fd9c/scripts/globals/common.lua#L39-L45