### PR TITLE
[bugfix] San d'oria Mission 9-2 : Refacto code + undo remove line in sql

### DIFF
--- a/scripts/zones/QuBia_Arena/Globals.lua
+++ b/scripts/zones/QuBia_Arena/Globals.lua
@@ -3,12 +3,14 @@
 -- Globals
 -----------------------------------
 local ID = require("scripts/zones/QuBia_Arena/IDs")
+local global = {}
 
 -----------------------------------
 -- Mission 9-2 SANDO
 -- BCNM: Heir to the light
 -----------------------------------
-function phaseChangeReady(battlefield)
+
+global.phaseChangeReady = function(battlefield)
     local inst = battlefield:getArea()
     printf("AreaID %i ", inst)
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
@@ -20,3 +22,5 @@ function phaseChangeReady(battlefield)
     end
     return true
 end
+
+return global

--- a/scripts/zones/QuBia_Arena/Globals.lua
+++ b/scripts/zones/QuBia_Arena/Globals.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: QuBia_Arena
+-- Globals
+-----------------------------------
+local ID = require("scripts/zones/QuBia_Arena/IDs")
+
+-----------------------------------
+-- Mission 9-2 SANDO
+-- BCNM: Heir to the light
+-----------------------------------
+function phaseChangeReady(battlefield)
+    local inst = battlefield:getArea()
+    printf("AreaID %i ", inst)
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
+    for i = instOffset + 3, instOffset + 13 do
+        printf("MobID %i isDead => %s ",i, GetMobByID(i):isDead() and 'T' or 'F')
+        if not GetMobByID(i):isDead() then
+            return false
+        end
+    end
+    return true
+end

--- a/scripts/zones/QuBia_Arena/Zone.lua
+++ b/scripts/zones/QuBia_Arena/Zone.lua
@@ -30,33 +30,6 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if csid == 32004 then
-        local battlefield = player:getBattlefield()
-        if battlefield then
-            local inst = battlefield:getArea()
-            local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-            local allyPos =
-            {
-                [1] = { trionPos = {-403, -201,  413, 58}, playerPos = {-400, -201,  419, 61} },
-                [2] = { trionPos = {  -3,   -1,    4, 61}, playerPos = {   0,   -1,   10, 61} },
-                [3] = { trionPos = { 397,  198, -395, 64}, playerPos = { 399,  198, -381, 57} },
-            }
-
-            -- spawn Warlord Rojnoj and its right and left hands.
-            for i = instOffset + 0, instOffset + 2 do
-                SpawnMob(i)
-            end
-
-            -- spawn trion and set ally positions
-            local allies = battlefield:getAllies()
-            if #allies == 0 then
-                local trion = battlefield:insertEntity(75, true, true)
-                trion:setSpawn(allyPos[inst].trionPos)
-                trion:spawn()
-            end
-            player:setPos(unpack(allyPos[inst].playerPos))
-        end
-    end
 end
 
 return zone_object

--- a/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
@@ -4,6 +4,7 @@
 -----------------------------------
 require("scripts/globals/battlefield")
 require("scripts/globals/missions")
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local battlefield_object = {}
 
@@ -35,8 +36,33 @@ battlefield_object.onEventUpdate = function(player, csid, option)
 end
 
 battlefield_object.onEventFinish = function(player, csid, option)
-    if
-        csid == 32001 and
+    if csid == 32004 then
+        local battlefield = player:getBattlefield()
+        if battlefield then
+            local inst = battlefield:getArea()
+            local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
+            local allyPos =
+            {
+                [1] = { trionPos = {-403, -201,  413, 58}, playerPos = {-400, -201,  419, 61} },
+                [2] = { trionPos = {  -3,   -1,    4, 61}, playerPos = {   0,   -1,   10, 61} },
+                [3] = { trionPos = { 397,  198, -395, 64}, playerPos = { 399,  198, -381, 57} },
+            }
+
+            -- spawn Warlord Rojnoj and its right and left hands.
+            for i = instOffset + 0, instOffset + 2 do
+                SpawnMob(i)
+            end
+
+            -- spawn trion and set ally positions
+            local allies = battlefield:getAllies()
+            if #allies == 0 then
+                local trion = battlefield:insertEntity(14183, true, true)
+                trion:setSpawn(unpack(allyPos[inst].trionPos))
+                trion:spawn()
+            end
+            player:setPos(unpack(allyPos[inst].playerPos))
+        end
+    elseif csid == 32001 and
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and
         player:getCharVar("MissionStatus") == 3
     then

--- a/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
@@ -56,7 +56,7 @@ battlefield_object.onEventFinish = function(player, csid, option)
             -- spawn trion and set ally positions
             local allies = battlefield:getAllies()
             if #allies == 0 then
-                local trion = battlefield:insertEntity(14183, true, true)
+                local trion = battlefield:insertEntity(75, true, true)
                 trion:setSpawn(unpack(allyPos[inst].trionPos))
                 trion:spawn()
             end

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -2,7 +2,7 @@
 -- Area: QuBia_Arena
 --  Mob: Death Clan Destroyer
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 require("scripts/globals/status")
 -----------------------------------
@@ -37,7 +37,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
         player:startEvent(32004, 0, 0, 4)
     end

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -2,6 +2,7 @@
 -- Area: QuBia_Arena
 --  Mob: Death Clan Destroyer
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 require("scripts/globals/status")
 -----------------------------------
@@ -9,17 +10,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(tpz.mobMod.HP_STANDBACK, 60)
-end
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
@@ -3,14 +3,14 @@
 --  Mob: Rallbrog of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
         player:startEvent(32004, 0, 0, 4)
     end

--- a/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
@@ -3,20 +3,10 @@
 --  Mob: Rallbrog of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
@@ -3,22 +3,12 @@
 --  Mob: Rojgnoj's Left Hand
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobInitialize = function(mob)
     mob:addMod(tpz.mod.SLEEPRES, 50)

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
@@ -3,7 +3,7 @@
 --  Mob: Rojgnoj's Left Hand
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
@@ -3,7 +3,7 @@
 --  Mob: Rojgnoj's Right Hand
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
@@ -3,22 +3,12 @@
 --  Mob: Rojgnoj's Right Hand
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobInitialize = function(mob)
     mob:addMod(tpz.mod.SLEEPRES, 50)

--- a/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
@@ -3,14 +3,14 @@
 --  Mob: Vangknok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
         player:startEvent(32004, 0, 0, 4)
     end

--- a/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
@@ -3,20 +3,10 @@
 --  Mob: Vangknok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()

--- a/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
@@ -3,7 +3,7 @@
 --  Mob: Warlord Rojgnoj
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
@@ -3,22 +3,12 @@
 --  Mob: Warlord Rojgnoj
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/status")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobInitialize = function(mob)
     mob:addMod(tpz.mod.SLEEPRES, 50)

--- a/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
@@ -3,20 +3,10 @@
 --  Mob: Worgbut of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()

--- a/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
@@ -3,14 +3,14 @@
 --  Mob: Worgbut of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
         player:startEvent(32004, 0, 0, 4)
     end

--- a/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
@@ -3,21 +3,11 @@
 --  Mob: Yukvok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
+require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 mixins = {require("scripts/mixins/job_special")}
 -----------------------------------
 local entity = {}
-
-local function phaseChangeReady(battlefield)
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
-    for i = instOffset + 3, instOffset + 13 do
-        if not GetMobByID(i):isDead() then
-            return false
-        end
-    end
-    return true
-end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()

--- a/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
@@ -3,7 +3,7 @@
 --  Mob: Yukvok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-require("scripts/zones/QuBia_Arena/Globals")
+local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
 mixins = {require("scripts/mixins/job_special")}
 -----------------------------------
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
     local battlefield = player:getBattlefield()
-    if battlefield and phaseChangeReady(battlefield) then
+    if battlefield and global.phaseChangeReady(battlefield) then
         player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
         player:startEvent(32004, 0, 0, 4)
     end

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -12986,8 +12986,6 @@ INSERT INTO `mob_groups` VALUES (73,0,206,'Ullegore',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (74,0,206,'Mumor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (75,4006,206,'Trion',0,128,0,0,0,75,75,1); -- ally
 
-INSERT INTO `mob_groups` VALUES (14183,4006,206,'Trion',0,128,0,0,0,75,75,1); -- Trion for rank mission 9-2
-
 -- ------------------------------------------------------------
 -- Cloister_of_Flames (Zone 207)
 -- ------------------------------------------------------------

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -12986,6 +12986,8 @@ INSERT INTO `mob_groups` VALUES (73,0,206,'Ullegore',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (74,0,206,'Mumor',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (75,4006,206,'Trion',0,128,0,0,0,75,75,1); -- ally
 
+INSERT INTO `mob_groups` VALUES (14183,4006,206,'Trion',0,128,0,0,0,75,75,1); -- Trion for rank mission 9-2
+
 -- ------------------------------------------------------------
 -- Cloister_of_Flames (Zone 207)
 -- ------------------------------------------------------------


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

The problem was that the second part of this BCNM was not strating.

I have move cs event in BCNM file instead of zone.lua who was not called.

Make a refacto for phaseChangeReady

@wrenffxi i see you have remove this line in sql but we need this for rank 9-2 San d'oria. Is there a problem with this line?

