### PR TITLE
kill testflag functions; modernize related NPC scripts

### DIFF
--- a/scripts/zones/Inner_Horutoto_Ruins/IDs.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/IDs.lua
@@ -25,6 +25,7 @@ zones[tpz.zone.INNER_HORUTOTO_RUINS] =
         NOT_BROKEN_ORB            = 7235,  -- The Mana Orb in this receptacle is not broken.
         EXAMINED_RECEPTACLE       = 7236,  -- You have already examined this receptacle.
         DOOR_FIRMLY_CLOSED        = 7263,  -- The door is firmly closed.
+        CAT_BURGLARS_HIDEOUT      = 7264,  -- It looks like that Cat Burglar's hideout lies behind this door! You were able to confirm <keyitem>!
         CHEST_UNLOCKED            = 7339,  -- You unlock the chest!
         PLAYER_OBTAINS_ITEM       = 7402,  -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM     = 7403,  -- You were unable to obtain the item.

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
@@ -5,8 +5,10 @@
 -- Involved in Mission 2-1
 -- !pos -11 0 20 192
 -----------------------------------
+require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -22,7 +24,7 @@ entity.onTrigger = function(player, npc)
     -- We should allow both missions and quests to activate
     if CurrentMission == tpz.mission.id.windurst.LOST_FOR_WORDS and MissionStatus == 4 then
         player:startEvent(46)
-    elseif MakingHeadlines == 1 then
+    elseif MakingHeadlines == QUEST_ACCEPTED then
         function testflag(set, flag)
             return (set % (2*flag) >= flag)
         end

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
@@ -5,6 +5,7 @@
 -- Involved in Mission 2-1
 -- !pos -11 0 20 192
 -----------------------------------
+local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
@@ -16,27 +17,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getCharVar("MissionStatus")
+    local makingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getCharVar("MissionStatus")
 
-    -- Check for Missions first (priority?)
-    -- We should allow both missions and quests to activate
-    if CurrentMission == tpz.mission.id.windurst.LOST_FOR_WORDS and MissionStatus == 4 then
+    -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
+    local prog = player:getCharVar("QuestMakingHeadlines_var")
+
+    if currentMission == tpz.mission.id.windurst.LOST_FOR_WORDS and missionStatus == 4 then
         player:startEvent(46)
-    elseif MakingHeadlines == QUEST_ACCEPTED then
-        function testflag(set, flag)
-            return (set % (2*flag) >= flag)
-        end
-
-        local prog = player:getCharVar("QuestMakingHeadlines_var")
-
-        if not testflag(tonumber(prog), 16) and testflag(tonumber(prog), 8) then
-            player:messageSpecial(7208, 1, tpz.ki.WINDURST_WOODS_SCOOP) -- Confirm Story
-            player:setCharVar("QuestMakingHeadlines_var", prog+16)
-        else
-            player:startEvent(44) -- "The door is firmly shut"
-        end
+    elseif
+        makingHeadlines == QUEST_ACCEPTED and
+        utils.mask.isFull(prog, 4) and
+        not utils.mask.getBit(prog, 4)
+    then
+        player:messageSpecial(ID.text.CAT_BURGLARS_HIDEOUT, 1, tpz.ki.WINDURST_WOODS_SCOOP) -- Confirm Story
+        player:setCharVar("QuestMakingHeadlines_var", utils.mask.setBit(prog, 4, true))
     else
         player:startEvent(44) -- "The door is firmly shut"
     end

--- a/scripts/zones/Norg/npcs/Aeka.lua
+++ b/scripts/zones/Norg/npcs/Aeka.lua
@@ -4,9 +4,9 @@
 -- Involved in Quest: Forge Your Destiny
 -- !pos 4 0 -4 252
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/quests")
 local ID = require("scripts/zones/Norg/IDs")
+require("scripts/globals/quests")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Norg/npcs/Aeka.lua
+++ b/scripts/zones/Norg/npcs/Aeka.lua
@@ -5,48 +5,35 @@
 -- !pos 4 0 -4 252
 -----------------------------------
 local ID = require("scripts/zones/Norg/IDs")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-
-    local questItem = player:getCharVar("ForgeYourDestiny_Event")
-    local checkItem = testflag(tonumber(questItem), 0x01)
-
-    if (checkItem == true) then
-        if (trade:hasItemQty(645, 1) and trade:getItemCount() == 1) then
-            player:startEvent(47, 0, 1151, 645) -- Oriental Steel, Darksteel Ore
-        end
+    if npcUtil.tradeHas(trade, 645) and utils.mask.getBit(player:getCharVar("ForgeYourDestiny_Event"), 0) then
+        player:startEvent(47, 0, 1151, 645) -- Oriental Steel, Darksteel Ore
     end
-
-end
-
-function testflag(set, flag)
-    return (set % (2*flag) >= flag)
 end
 
 entity.onTrigger = function(player, npc)
-
+    local forgeYourDestiny = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.FORGE_YOUR_DESTINY)
     local swordTimer = player:getCharVar("ForgeYourDestiny_timer")
 
-    if (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.FORGE_YOUR_DESTINY) == QUEST_ACCEPTED and swordTimer == 0) then
-        if (player:hasItem(1152)) then
+    if forgeYourDestiny == QUEST_ACCEPTED and swordTimer == 0 then
+        if player:hasItem(1152) then
             player:startEvent(48, 1152) -- Bomb Steel
-        elseif (player:hasItem(1151) == false) then
-            local questItem = player:getCharVar("ForgeYourDestiny_Event")
-            local checkItem = testflag(tonumber(questItem), 0x01)
-
-            if (checkItem == false) then
+        elseif not player:hasItem(1151) then
+            if not utils.mask.getBit(player:getCharVar("ForgeYourDestiny_Event"), 0) then
                 player:startEvent(44, 1152, 1151) -- Bomb Steel, Oriental Steel
-            elseif (checkItem == true) then
+            else
                 player:startEvent(46, 0, 1151, 645) -- Oriental Steel, Darksteel Ore
             end
-        elseif (player:hasItem(1151)) then
+        else
             player:startEvent(45, 1152, 1151) -- Bomb Steel, Oriental Steel
         end
-    elseif (swordTimer > 0) then
+    elseif swordTimer > 0 then
         player:startEvent(50)
     else
         player:startEvent(120)
@@ -61,22 +48,10 @@ entity.onEventFinish = function(player, csid, option)
 
     local questItem = player:getCharVar("ForgeYourDestiny_Event")
 
-    if (csid == 44) then
-        if (player:getFreeSlotsCount(0) >= 1) then
-            player:addItem(1151)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 1151) -- Oriental Steel
-            player:setCharVar("ForgeYourDestiny_Event", questItem + 0x01)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1151) -- Oriental Steel
-        end
-    elseif (csid == 47) then
-        if (player:getFreeSlotsCount(0) >= 1) then
-            player:tradeComplete()
-            player:addItem(1151)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 1151) -- Oriental Steel
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1151) -- Oriental Steel
-        end
+    if csid == 44 and npcUtil.giveItem(player, 1151) then
+        player:setCharVar("ForgeYourDestiny_Event", utils.mask.setBit(player:getCharVar("ForgeYourDestiny_Event"), 0, true))
+    elseif csid == 47 and npcUtil.giveItem(player, 1151) then
+        player:confirmTrade()
     end
 
 end

--- a/scripts/zones/Norg/npcs/Ranemaud.lua
+++ b/scripts/zones/Norg/npcs/Ranemaud.lua
@@ -4,55 +4,43 @@
 -- Involved in Quest: Forge Your Destiny, The Sacred Katana
 -- !pos 15 0 23 252
 -----------------------------------
-local ID = require("scripts/zones/Norg/IDs")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local theSacredKatana = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.THE_SACRED_KATANA)
 
-    local questItem = player:getCharVar("ForgeYourDestiny_Event")
-    local checkItem = testflag(tonumber(questItem), 0x02)
-
-    if (checkItem == true) then
-        if (trade:hasItemQty(738, 1) and trade:hasItemQty(737, 2) and trade:getItemCount() == 3) then
-            player:startEvent(43, 0, 0, 738, 737) -- Platinum Ore, Gold Ore
-        end
+    if npcUtil.tradeHas(trade, {{737, 2}, 738}) then
+        player:startEvent(43, 0, 0, 738, 737) -- Platinum Ore, Gold Ore
+    elseif
+        theSacredKatana == QUEST_ACCEPTED and
+        not player:hasItem(17809) and
+        npcUtil.tradeHas(trade, {{"gil", 30000}})
+    then
+        player:startEvent(145)
     end
-
-    if (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.THE_SACRED_KATANA) == QUEST_ACCEPTED and player:hasItem(17809) == false) then
-        if (trade:getGil() == 30000 and trade:getItemCount() == 1 and player:getFreeSlotsCount() >= 1) then
-            player:startEvent(145)
-        end
-    end
-
-end
-
-function testflag(set, flag)
-    return (set % (2*flag) >= flag)
 end
 
 entity.onTrigger = function(player, npc)
-
+    local forgeYourDestiny = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.FORGE_YOUR_DESTINY)
     local swordTimer = player:getCharVar("ForgeYourDestiny_timer")
+    local theSacredKatana = player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.THE_SACRED_KATANA)
 
-    if (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.FORGE_YOUR_DESTINY) == QUEST_ACCEPTED and swordTimer == 0) then
-        if (player:hasItem(1153)) then
+    if forgeYourDestiny == QUEST_ACCEPTED and swordTimer == 0 then
+        if player:hasItem(1153) then
             player:startEvent(48, 1153) -- Sacred Branch
-        elseif (player:hasItem(1198) == false) then
-            local questItem = player:getCharVar("ForgeYourDestiny_Event")
-            local checkItem = testflag(tonumber(questItem), 0x02)
-
-            if (checkItem == false) then
+        elseif not player:hasItem(1198) then
+            if not utils.mask.getBit(player:getCharVar("ForgeYourDestiny_Event"), 1) then
                 player:startEvent(40, 1153, 1198) -- Sacred Branch, Sacred Sprig
-            elseif (checkItem == true) then
-                player:startEvent(42, 0, 0, 738, 737) -- Platinum Ore, Gold Ore
+            else
+                player:startEvent(42, 0, 1198, 738, 737) -- Platinum Ore, Gold Ore
             end
-        elseif (player:hasItem(1198)) then -- Sacred Sprig
+        else
             player:startEvent(41)
         end
-    elseif (player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.THE_SACRED_KATANA) == QUEST_ACCEPTED and player:hasItem(17809) == false) then
+    elseif theSacredKatana == QUEST_ACCEPTED and not player:hasItem(17809) then
         player:startEvent(144)
     else
         player:startEvent(68)
@@ -63,31 +51,13 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    local questItem = player:getCharVar("ForgeYourDestiny_Event")
-
-    if (csid == 40) then
-        if (player:getFreeSlotsCount(0) >= 1) then
-            player:addItem(1198)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 1198) -- Sacred Sprig
-            player:setCharVar("ForgeYourDestiny_Event", questItem + 0x02)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1151) -- Oriental Steel
-        end
-    elseif (csid == 43) then
-        if (player:getFreeSlotsCount(0) >= 1) then
-            player:tradeComplete()
-            player:addItem(1198)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 1198) -- Sacred Sprig
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1198) -- Sacred Sprig
-        end
-    elseif (csid == 145) then
-        player:tradeComplete()
-        player:addItem(17809)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 17809) -- Mumeito
+    if csid == 40 and npcUtil.giveItem(player, 1198) then
+        player:setCharVar("ForgeYourDestiny_Event", utils.mask.setBit(player:getCharVar("ForgeYourDestiny_Event"), 1, true))
+    elseif csid == 43 and npcUtil.giveItem(player, 1198) then
+        player:confirmTrade()
+    elseif csid == 145 and npcUtil.giveItem(player, 17809) then
+        player:confirmTrade()
     end
-
 end
 
 return entity

--- a/scripts/zones/Norg/npcs/Ranemaud.lua
+++ b/scripts/zones/Norg/npcs/Ranemaud.lua
@@ -4,9 +4,9 @@
 -- Involved in Quest: Forge Your Destiny, The Sacred Katana
 -- !pos 15 0 23 252
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/quests")
 local ID = require("scripts/zones/Norg/IDs")
+require("scripts/globals/quests")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Port_Windurst/npcs/Yujuju.lua
+++ b/scripts/zones/Port_Windurst/npcs/Yujuju.lua
@@ -5,9 +5,7 @@
 -- !pos 201.523 -4.785 138.978 240
 -----------------------------------
 local ID = require("scripts/zones/Port_Windurst/IDs")
-require("scripts/globals/settings")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
@@ -27,7 +25,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(621)
     elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status")==9) then
         player:startEvent(592)--COP event
-    elseif (MakingHeadlines == 1) then
+    elseif (MakingHeadlines == QUEST_ACCEPTED) then
         local prog = player:getCharVar("QuestMakingHeadlines_var")
         --  Variable to track if player has talked to 4 NPCs and a door
         --  1 = Kyume
@@ -54,7 +52,7 @@ entity.onEventFinish = function(player, csid, option)
         player:addKeyItem(tpz.ki.PORT_WINDURST_SCOOP)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PORT_WINDURST_SCOOP)
         player:setCharVar("QuestMakingHeadlines_var", prog+2)
-    elseif (csid == 592)    then
+    elseif (csid == 592) then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 10)
     elseif (csid == 621) then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 19, true))

--- a/scripts/zones/Port_Windurst/npcs/Yujuju.lua
+++ b/scripts/zones/Port_Windurst/npcs/Yujuju.lua
@@ -4,7 +4,8 @@
 --  Involved In Quest: Making Headlines
 -- !pos 201.523 -4.785 138.978 240
 -----------------------------------
-local ID = require("scripts/zones/Port_Windurst/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
@@ -14,26 +15,19 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
+    local makingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
+    local lureOfTheWildcat = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
+    local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 19)) then
+    if lureOfTheWildcat == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 19) then
         player:startEvent(621)
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status")==9) then
-        player:startEvent(592)--COP event
-    elseif (MakingHeadlines == QUEST_ACCEPTED) then
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 9 then
+        player:startEvent(592)
+    elseif makingHeadlines == QUEST_ACCEPTED then
+        -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
         local prog = player:getCharVar("QuestMakingHeadlines_var")
-        --  Variable to track if player has talked to 4 NPCs and a door
-        --  1 = Kyume
-        -- 2 = Yujuju
-        -- 4 = Hiwom
-        -- 8 = Umumu
-        -- 16 = Mahogany Door
-        if (testflag(tonumber(prog), 2) == false) then
+
+        if not utils.mask.getBit(prog, 1) then
             player:startEvent(314) -- Get Scoop
         else
             player:startEvent(315) -- After receiving scoop
@@ -47,14 +41,12 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 314) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
-        player:addKeyItem(tpz.ki.PORT_WINDURST_SCOOP)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PORT_WINDURST_SCOOP)
-        player:setCharVar("QuestMakingHeadlines_var", prog+2)
-    elseif (csid == 592) then
+    if csid == 314 then
+        npcUtil.giveKeyItem(player, tpz.ki.PORT_WINDURST_SCOOP)
+        player:setCharVar("QuestMakingHeadlines_var", utils.mask.setBit(player:getCharVar("QuestMakingHeadlines_var"), 1, true))
+    elseif csid == 592 then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 10)
-    elseif (csid == 621) then
+    elseif csid == 621 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 19, true))
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
@@ -4,10 +4,10 @@
 --  Involved In Quest: Making Headlines, Curses, Foiled...Again!?
 -- Working 100%
 -----------------------------------
-require("scripts/globals/quests")
-require("scripts/globals/settings")
-require("scripts/globals/titles")
 local ID = require("scripts/zones/Windurst_Walls/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
 
     -- Making Headlines
     elseif (MakingHeadlines == 1) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
+        local prog = player:getCharVar("QuestMakingHeadlines_var")
         --  Variable to track if player has talked to 4 NPCs and a door
         --  1 = Kyume
         -- 2 = Yujuju
@@ -53,19 +53,14 @@ entity.onTrigger = function(player, npc)
     else
         local rand = math.random(1, 5)
         if (rand == 1) then
-            print (rand)
             player:startEvent(305) -- Standard Conversation
         elseif (rand == 2) then
-            print (rand)
             player:startEvent(306) -- Standard Conversation
         elseif (rand == 3) then
-            print (rand)
             player:startEvent(168) -- Standard Conversation
         elseif (rand == 4) then
-            print (rand)
             player:startEvent(170) -- Standard Conversation
         elseif (rand == 5) then
-            print (rand)
             player:startEvent(169) -- Standard Conversation
         end
     end
@@ -79,7 +74,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- Making Headlines
     if (csid == 281 or csid == 283 or csid == 284) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
+        local prog = player:getCharVar("QuestMakingHeadlines_var")
         player:addKeyItem(tpz.ki.WINDURST_WALLS_SCOOP)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WINDURST_WALLS_SCOOP)
         player:setCharVar("QuestMakingHeadlines_var", prog+4)

--- a/scripts/zones/Windurst_Waters/npcs/Baren-Moren.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Baren-Moren.lua
@@ -9,11 +9,12 @@ require("scripts/globals/settings")
 require("scripts/globals/keyitems")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
+    local featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
     if (featherstatus >= 1 and trade:hasItemQty(842, 3) == true and trade:getGil() == 0 and trade:getItemCount() == 3) then
         player:startEvent(79, 1500) -- Quest Turn In
     end
@@ -27,14 +28,14 @@ entity.onTrigger = function(player, npc)
     function testflag(set, flag)
         return (set % (2*flag) >= flag)
     end
-    hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
-    pfame = player:getFameLevel(WINDURST)
-    if (hatstatus == 0) then
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    local featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
+    local pfame = player:getFameLevel(WINDURST)
+    if (hatstatus == QUEST_AVAILABLE) then
         player:startEvent(48) -- Quest Offered
---    elseif ((hatstatus == 1 or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_count") == 0) then
+--    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_count") == 0) then
 --        player:startEvent(51, 80) -- Hat in Hand: During Quest - Objective Reminder
-    elseif (hatstatus == 1 or player:getCharVar("QuestHatInHand_var2") == 1) then
+    elseif (hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) then
         --     Variable to track quest progress
         --     1 = Machitata       !pos 163 0 -22
         --    2 = Honoi-Gomoi       !pos -195 -11 -120
@@ -44,7 +45,7 @@ entity.onTrigger = function(player, npc)
         --  32 = Tosuka-Porika    !pos -26 -6 103
         --  64 = Pechiru-Mashiru !pos 162 -2 159
         --  128 = Bondada        !pos -66 -3 -148
-        count = player:getCharVar("QuestHatInHand_count")
+        local count = player:getCharVar("QuestHatInHand_count")
         if (count == 8) then                 -- 80 = HAT + FULL REWARD  =  8 NPCS - Option 5
             player:startEvent(52, 80)
         elseif (count >= 6) then            -- 50 = HAT + GOOD REWARD  >= 6-7 NPCS - Option 4
@@ -56,18 +57,18 @@ entity.onTrigger = function(player, npc)
         else                                -- 0/nill = NO REWARD         >= 0-1 NPCS - Option 1
             player:startEvent(52)
         end
-    elseif (featherstatus == 1 or player:getCharVar("QuestFeatherInOnesCap_var") == 1) then
+    elseif (featherstatus == QUEST_ACCEPTED or player:getCharVar("QuestFeatherInOnesCap_var") == 1) then
         player:startEvent(78, 0, 842) -- Quest Objective Reminder
-    elseif (hatstatus == 2 and featherstatus == 0 and pfame >= 3 and player:needToZone() == false and player:getCharVar("QuestHatInHand_var2") == 0) then
-        rand = math.random(1, 2)
+    elseif (hatstatus == QUEST_COMPLETED and featherstatus == QUEST_AVAILABLE and pfame >= 3 and player:needToZone() == false and player:getCharVar("QuestHatInHand_var2") == 0) then
+        local rand = math.random(1, 2)
         if (rand == 1) then
             player:startEvent(75, 0, 842) -- Quest "Feather In One's Cap" offered
         else
             player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
         end
 
-    elseif     (featherstatus == 2 and player:needToZone() == false) then
-        rand = math.random(1, 2)
+    elseif (featherstatus == QUEST_COMPLETED and player:needToZone() == false) then
+        local rand = math.random(1, 2)
         if (rand == 1) then
             player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
         else
@@ -75,8 +76,8 @@ entity.onTrigger = function(player, npc)
         end
     elseif (player:needToZone() == false) then
         player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
-    else   --  Will run through these if fame is not high enough for other quests
-        rand = math.random(1, 6)
+    else -- Will run through these if fame is not high enough for other quests
+        local rand = math.random(1, 6)
         if (rand == 1) then
             player:startEvent(42) -- Standard Conversation 1
         elseif (rand == 2) then
@@ -97,7 +98,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-printf("RESULT: %u", option)
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+
     if (csid == 48 and option == 1) then
         player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
         player:addKeyItem(tpz.ki.NEW_MODEL_HAT)
@@ -131,7 +133,7 @@ printf("RESULT: %u", option)
             player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*150)
 --        else (option == 1) then     -- 0/nill = NO REWARD      >= 0 NPCS - Option 1
         end
-        if (hatstatus == 1) then
+        if (hatstatus == QUEST_ACCEPTED) then
             player:addFame(WINDURST, 75)
         else
             player:addFame(WINDURST, 8)

--- a/scripts/zones/Windurst_Waters/npcs/Baren-Moren.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Baren-Moren.lua
@@ -7,6 +7,7 @@
 local ID = require("scripts/zones/Windurst_Waters/IDs")
 require("scripts/globals/settings")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
 require("scripts/globals/utils")
@@ -14,81 +15,67 @@ require("scripts/globals/utils")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
-    if (featherstatus >= 1 and trade:hasItemQty(842, 3) == true and trade:getGil() == 0 and trade:getItemCount() == 3) then
+    local aFeatherInOnesCap = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
+
+    if
+        (
+            aFeatherInOnesCap == QUEST_ACCEPTED or
+            player:getCharVar("QuestFeatherInOnesCap_var") == 1
+        ) and
+        npcUtil.tradeHas(trade, {{842, 3}})
+    then
         player:startEvent(79, 1500) -- Quest Turn In
     end
 end
 
 entity.onTrigger = function(player, npc)
-
---    player:delQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)  -- ================== FOR TESTING ONLY =====================
---    player:addFame(WINDURST, 200)   -- ================== FOR TESTING ONLY =====================
-
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    local featherstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
+    local hatInHand = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    local aFeatherInOnesCap = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
     local pfame = player:getFameLevel(WINDURST)
-    if (hatstatus == QUEST_AVAILABLE) then
-        player:startEvent(48) -- Quest Offered
---    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_count") == 0) then
---        player:startEvent(51, 80) -- Hat in Hand: During Quest - Objective Reminder
-    elseif (hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) then
-        --     Variable to track quest progress
-        --     1 = Machitata       !pos 163 0 -22
-        --    2 = Honoi-Gomoi       !pos -195 -11 -120
-        --    4 = Kenapa-Keppa    !pos 27 -6 -199
-        --    8 = Clais            !pos -31 -3 11
-        --    16 = Kyume-Romeh    !pos -58 -4 23
-        --  32 = Tosuka-Porika    !pos -26 -6 103
-        --  64 = Pechiru-Mashiru !pos 162 -2 159
-        --  128 = Bondada        !pos -66 -3 -148
-        local count = player:getCharVar("QuestHatInHand_count")
-        if (count == 8) then                 -- 80 = HAT + FULL REWARD  =  8 NPCS - Option 5
-            player:startEvent(52, 80)
-        elseif (count >= 6) then            -- 50 = HAT + GOOD REWARD  >= 6-7 NPCS - Option 4
-            player:startEvent(52, 50)
-        elseif (count >= 4) then            -- 30 = PARTIAL REWARD -   >= 4-5 NPCS - Option 3
-            player:startEvent(52, 30)
-        elseif (count >= 2) then            -- 20 = POOR REWARD         >= 2-3 NPCS - Option 2
-            player:startEvent(52, 20)
-        else                                -- 0/nill = NO REWARD         >= 0-1 NPCS - Option 1
-            player:startEvent(52)
-        end
-    elseif (featherstatus == QUEST_ACCEPTED or player:getCharVar("QuestFeatherInOnesCap_var") == 1) then
-        player:startEvent(78, 0, 842) -- Quest Objective Reminder
-    elseif (hatstatus == QUEST_COMPLETED and featherstatus == QUEST_AVAILABLE and pfame >= 3 and player:needToZone() == false and player:getCharVar("QuestHatInHand_var2") == 0) then
-        local rand = math.random(1, 2)
-        if (rand == 1) then
-            player:startEvent(75, 0, 842) -- Quest "Feather In One's Cap" offered
-        else
-            player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
-        end
 
-    elseif (featherstatus == QUEST_COMPLETED and player:needToZone() == false) then
-        local rand = math.random(1, 2)
-        if (rand == 1) then
-            player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
+    if hatInHand == QUEST_AVAILABLE then
+        player:startEvent(48) -- Quest Offered
+    elseif player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) then
+        local count = player:getCharVar("QuestHatInHand_count")
+
+        if count >= 8 then
+            player:startEvent(52, 80) -- 80 = HAT + FULL REWARD = 8 NPCS
+            player:setLocalVar("hatRewardTier", 5)
+        elseif count >= 6 then
+            player:startEvent(52, 50) -- 50 = HAT + GOOD REWARD >= 6-7 NPCS
+            player:setLocalVar("hatRewardTier", 4)
+        elseif count >= 4 then
+            player:startEvent(52, 30) -- 30 = PARTIAL REWARD >= 4-5 NPCS
+            player:setLocalVar("hatRewardTier", 3)
+        elseif count >= 2 then
+            player:startEvent(52, 20) -- 20 = POOR REWARD >= 2-3 NPCS
+            player:setLocalVar("hatRewardTier", 2)
         else
-            player:startEvent(75, 0, 842) -- Repeatable Quest "A Feather In One's Cap" offered
+            player:startEvent(52) -- 0 = NO REWARD >= 0-1 NPCS
+            player:setLocalVar("hatRewardTier", 1)
         end
-    elseif (player:needToZone() == false) then
-        player:startEvent(49) -- Repeatable Quest "Hat In Hand" offered
-    else -- Will run through these if fame is not high enough for other quests
+    elseif hatInHand == QUEST_COMPLETED and aFeatherInOnesCap == QUEST_AVAILABLE and pfame >= 3 and not player:needToZone() then
+        player:startEvent(75, 0, 842) -- Quest "Feather In One's Cap" offered
+    elseif aFeatherInOnesCap == QUEST_ACCEPTED or player:getCharVar("QuestFeatherInOnesCap_var") == 1 then
+        player:startEvent(78, 0, 842) -- Quest Objective Reminder
+    elseif aFeatherInOnesCap == QUEST_COMPLETED and not player:needToZone() then
+        player:startEvent(75, 0, 842) -- Repeatable Quest "A Feather In One's Cap" offered
+
+    -- default dialog
+    else
         local rand = math.random(1, 6)
-        if (rand == 1) then
+
+        if rand == 1 then
             player:startEvent(42) -- Standard Conversation 1
-        elseif (rand == 2) then
+        elseif rand == 2 then
             player:startEvent(44) -- Standard Conversation 2
-        elseif (rand == 3) then
+        elseif rand == 3 then
             player:startEvent(45) -- Standard Conversation 3
-        elseif (rand == 4) then
+        elseif rand == 4 then
             player:startEvent(46) -- Standard Conversation 4
-        elseif (rand == 5) then
+        elseif rand == 5 then
             player:startEvent(47) -- Standard Conversation 5
-        elseif (rand == 6) then
+        elseif rand == 6 then
             player:startEvent(1022) -- Standard Conversation 6
         end
     end
@@ -98,70 +85,48 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    local aFeatherInOnesCap = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
 
-    if (csid == 48 and option == 1) then
+    if csid == 48 and option == 1 then
         player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-        player:addKeyItem(tpz.ki.NEW_MODEL_HAT)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.NEW_MODEL_HAT)
-    elseif (csid == 49 and option == 1) then
-        player:setCharVar("QuestHatInHand_var2", 1)
-        player:addKeyItem(tpz.ki.NEW_MODEL_HAT)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.NEW_MODEL_HAT)
-    elseif (csid == 52 and option >= 4 and player:getFreeSlotsCount(0) == 0) then
-        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12543)
-    elseif (csid == 52 and option >= 1) then
-        if (option == 5) then          --    80 = HAT + FULL REWARD  =  8 NPCS - Option 5
-            player:addGil(GIL_RATE*500)
-            player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*500)
-            if (player:hasItem(12543) == false) then
-                player:addItem(12543, 1)
-                player:messageSpecial(ID.text.ITEM_OBTAINED, 12543)
-            end
-        elseif (option == 4) then     -- 50 = HAT + GOOD REWARD  >= 6 NPCS - Option 4
-            player:addGil(GIL_RATE*400)
-            player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*400)
-            if (player:hasItem(12543) == false) then
-                player:addItem(12543, 1)
-                player:messageSpecial(ID.text.ITEM_OBTAINED, 12543)
-            end
-        elseif (option == 3) then     -- 30 = PARTIAL REWARD -   >= 4 NPCS - Option 3
-            player:addGil(GIL_RATE*300)
-            player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*300)
-        elseif (option == 2) then     -- 20 = POOR REWARD         >= 2 NPCS - Option 2
-            player:addGil(GIL_RATE*150)
-            player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*150)
---        else (option == 1) then     -- 0/nill = NO REWARD      >= 0 NPCS - Option 1
-        end
-        if (hatstatus == QUEST_ACCEPTED) then
-            player:addFame(WINDURST, 75)
-        else
-            player:addFame(WINDURST, 8)
-        end
-        player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-        player:setCharVar("QuestHatInHand_count", 0)
-        player:setCharVar("QuestHatInHand_var", 0)
-        player:needToZone(true)
-        player:delKeyItem(tpz.ki.NEW_MODEL_HAT)
-        player:setCharVar("QuestHatInHand_var2", 0)
+        npcUtil.giveKeyItem(player, tpz.ki.NEW_MODEL_HAT)
+    elseif csid == 52 and option >= 1 then
+        local rewardTier = player:getLocalVar("hatRewardTier")
+        local rewards = {fame = 75, var = {"QuestHatInHand_var", "QuestHatInHand_count"}}
 
+        if rewardTier == 5 then
+            rewards.gil = 500
+            rewards.item = 12543
+        elseif rewardTier == 4 then
+            rewards.gil = 400
+            rewards.item = 12543
+        elseif rewardTier == 3 then
+            rewards.gil = 300
+        elseif rewardTier == 2 then
+            rewards.gil = 150
+        elseif rewardTier == 1 then
+            rewards.gil = 300
+        end
 
-    elseif (csid == 75 and option == 1) then
-        if (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP) == QUEST_AVAILABLE) then
+        if npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.HAT_IN_HAND, rewards) then
+            player:delKeyItem(tpz.ki.NEW_MODEL_HAT)
+            player:needToZone(true)
+        end
+    elseif csid == 75 and option == 1 then
+        if aFeatherInOnesCap == QUEST_AVAILABLE then
             player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
-        elseif (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP) == QUEST_COMPLETED) then
+        elseif aFeatherInOnesCap == QUEST_COMPLETED then
             player:setCharVar("QuestFeatherInOnesCap_var", 1)
         end
-    elseif (csid == 79) then
-        if (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP) == QUEST_ACCEPTED) then
-            player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP)
-            player:addFame(WINDURST, 75)
+    elseif csid == 79 then
+        if aFeatherInOnesCap == QUEST_ACCEPTED then
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.A_FEATHER_IN_ONE_S_CAP, {fame = 75})
         else
             player:addFame(WINDURST, 8)
             player:setCharVar("QuestFeatherInOnesCap_var", 0)
         end
-        player:addGil(GIL_RATE*1500)
-        player:tradeComplete(trade)
+        player:addGil(GIL_RATE * 1500)
+        player:confirmTrade()
         player:needToZone(true)
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Bondada.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Bondada.lua
@@ -5,8 +5,7 @@
 -- !pos -66 -3 -148 238
 -----------------------------------
 require("scripts/globals/quests")
-require("scripts/globals/settings")
-require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -17,10 +16,10 @@ entity.onTrigger = function(player, npc)
     function testflag(set, flag)
         return (set % (2*flag) >= flag)
     end
-    hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == 1  or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_var") < 127) then
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_var") < 127) then
         player:startEvent(53) -- Show Off Hat (She does not buy one)
-    elseif ((hatstatus == 1 or player:getCharVar("QuestHatInHand_var2") == 1)  and player:getCharVar("QuestHatInHand_var") == 127) then
+    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1)  and player:getCharVar("QuestHatInHand_var") == 127) then
         player:startEvent(61) -- Show Off Hat (She buys one)
     else
         player:startEvent(43) -- Standard Conversation
@@ -31,7 +30,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 61) then  -- Show Off Hat
+    if (csid == 61) then -- Show Off Hat
         player:addCharVar("QuestHatInHand_var", 128)
         player:addCharVar("QuestHatInHand_count", 1)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Bondada.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Bondada.lua
@@ -4,6 +4,8 @@
 -- Involved in Quests: Hat in Hand
 -- !pos -66 -3 -148 238
 -----------------------------------
+local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
@@ -13,14 +15,17 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and player:getCharVar("QuestHatInHand_var") < 127) then
-        player:startEvent(53) -- Show Off Hat (She does not buy one)
-    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1)  and player:getCharVar("QuestHatInHand_var") == 127) then
-        player:startEvent(61) -- Show Off Hat (She buys one)
+    local hatInHand = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    local hatMask = player:getCharVar("QuestHatInHand_var")
+
+    if player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(hatMask, 7) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+
+        if utils.mask.isFull(hatMask, 7) then
+            player:startEvent(61) -- Show Off Hat (She buys one)
+        else
+            player:startEvent(53) -- Show Off Hat (She does not buy one)
+        end
     else
         player:startEvent(43) -- Standard Conversation
     end
@@ -30,8 +35,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 61) then -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 128)
+    if csid == 61 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 7, true))
         player:addCharVar("QuestHatInHand_count", 1)
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Clais.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Clais.lua
@@ -4,7 +4,8 @@
 -- Involved In Quest: Hat in Hand
 -- !pos -31 -3 11 238
 -----------------------------------
-require("scripts/globals/quests")
+local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
@@ -13,12 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 8) == false) then
-        player:startEvent(57) -- Show Off Hat
+    if player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 3) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(57)
     else
         player:startEvent(602) -- Standard Conversation
     end
@@ -28,8 +26,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 57) then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 8)
+    if csid == 57 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 3, true))
         player:addCharVar("QuestHatInHand_count", 1)
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Clais.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Clais.lua
@@ -5,7 +5,7 @@
 -- !pos -31 -3 11 238
 -----------------------------------
 require("scripts/globals/quests")
-require("scripts/globals/settings")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -16,8 +16,8 @@ entity.onTrigger = function(player, npc)
     function testflag(set, flag)
         return (set % (2*flag) >= flag)
     end
-    hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == 1 or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 8) == false) then
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 8) == false) then
         player:startEvent(57) -- Show Off Hat
     else
         player:startEvent(602) -- Standard Conversation

--- a/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
@@ -9,6 +9,7 @@ require("scripts/globals/missions")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
@@ -4,6 +4,7 @@
 -- Involved In Quest: Crying Over Onions, Hat in Hand
 -- !pos -195 -11 -120 238
 -----------------------------------
+local ID = require("scripts/zones/Windurst_Waters/IDs")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/npc_util")
@@ -25,40 +26,26 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-
     local cryingOverOnions  = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS)
     local wildCard          = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.WILD_CARD)
-    local hatInHand         = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
 
     if
         player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and
         player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 5
     then
         player:startEvent(874) -- COP event
-    elseif
-        (hatInHand == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and
-        not testflag(player:getCharVar("QuestHatInHand_var"), 2)
-    then
-        player:startEvent(59) -- Show Off Hat
-    elseif wildCard == QUEST_COMPLETED then
-        player:startEvent(783)
+    elseif player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 1) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(59)
     elseif wildCard == QUEST_ACCEPTED then
         if player:getCharVar("WildCard") == 3 and not player:hasKeyItem(tpz.ki.JOKER_CARD) then
             player:startEvent(782)
         else
             player:startEvent(781)
         end
-    elseif cryingOverOnions == QUEST_COMPLETED then
-        if not player:needToZone() and player:getFameLevel(WINDURST) >= 6 then
-            player:startEvent(780)
-        else
-            player:startEvent(779)
-        end
     elseif cryingOverOnions == QUEST_ACCEPTED then
         local cryingOverOnionsVar = player:getCharVar("CryingOverOnions")
+
         if cryingOverOnionsVar == 4 then
             player:startEvent(776)
         elseif cryingOverOnionsVar == 3 then
@@ -67,6 +54,14 @@ entity.onTrigger = function(player, npc)
             player:startEvent(777)
         else
             player:startEvent(774, 0, 1149)
+        end
+    elseif wildCard == QUEST_COMPLETED then
+        player:startEvent(783)
+    elseif cryingOverOnions == QUEST_COMPLETED then
+        if not player:needToZone() and player:getFameLevel(WINDURST) >= 6 then
+            player:startEvent(780)
+        else
+            player:startEvent(779)
         end
     else
         player:startEvent(650)
@@ -87,8 +82,8 @@ entity.onEventFinish = function(player, csid, option)
     elseif
         csid == 776 and
         npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS, {
-            fame=120,
-            var="CryingOverOnions",
+            fame = 120,
+            var = "CryingOverOnions",
         })
     then
         player:needToZone(true)
@@ -99,16 +94,16 @@ entity.onEventFinish = function(player, csid, option)
     elseif
         csid == 782 and
         npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.WILD_CARD, {
-            title=tpz.title.DREAM_DWELLER,
-            fame=135,
-            var="WildCard",
+            title = tpz.title.DREAM_DWELLER,
+            fame = 135,
+            var = "WildCard",
         })
     then
         player:needToZone(true)
 
     -- "Hat in Hand"
-    elseif csid == 59 then -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 2)
+    elseif csid == 59 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 1, true))
         player:addCharVar("QuestHatInHand_count", 1)
 
     -- COP Misson 3-3B "Memories of a Maiden"

--- a/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
@@ -6,6 +6,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
@@ -14,122 +15,132 @@ require("scripts/globals/utils")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local FoodForThought = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT)
-    local KenapaFood = player:getCharVar("Kenapa_Food_var") -- Variable to track progress of Kenapa-Keppa in Food for Thought
+    local foodForThought = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT)
+    local kenapaFood = player:getCharVar("Kenapa_Food_var") -- Variable to track progress of Kenapa-Keppa in Food for Thought
 
-    if (FoodForThought == QUEST_ACCEPTED) then
-        local count = trade:getItemCount()
-        local gil = trade:getGil()
-        if (trade:hasItemQty(4409, 1) == false) then -- Traded in wrong item. Not accepted.
-            player:startEvent(329)
-        elseif (count == 1 and trade:hasItemQty(4409, 1) == true and gil == 0) then
-            if (KenapaFood < 3) then -- Traded item without receiving order
-                if (math.random(1, 2) == 1) then
+    if foodForThought == QUEST_ACCEPTED then
+        if npcUtil.tradeHas(trade, 4409) then -- hard-boiled_egg
+            if kenapaFood < 3 then -- Traded item without receiving order
+                if math.random(1, 2) == 1 then
                     player:startEvent(331)
                 else
                     player:startEvent(330, 120)
                 end
-            elseif (KenapaFood == 3) then  -- Traded item after receiving order
+            elseif kenapaFood == 3 then -- Traded item after receiving order
                 player:startEvent(327, 120)
             end
+        else
+            player:startEvent(329) -- trade not accepted
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-
-    local OvernightDelivery = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY)
-    local FoodForThought = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT)
-    local SayFlowers = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.SAY_IT_WITH_FLOWERS)
-    local FlowerProgress = player:getCharVar("FLOWER_PROGRESS") -- Variable to track progress of Say It with Flowers.
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    local KenapaFood = player:getCharVar("Kenapa_Food_var") -- Variable to track progress of Kenapa-Keppa in Food for Thought
-    local KenapaOvernight = player:getCharVar("Kenapa_Overnight_var") -- Variable to track progress for Overnight Delivery
-    local KenapaOvernightDay = player:getCharVar("Kenapa_Overnight_Day_var") -- Variable to track the day the quest is started.
-    local KenapaOvernightHour = player:getCharVar("Kenapa_Overnight_Hour_var") -- Variable to track the hour the quest is started.
+    local overnightDelivery = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY)
+    local foodForThought = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT)
+    local sayItWithFlowers = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.SAY_IT_WITH_FLOWERS)
+    local flowerProgress = player:getCharVar("FLOWER_PROGRESS") -- progress of Say It with Flowers
+    local hatInHand = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    local kenapaFood = player:getCharVar("Kenapa_Food_var") -- progress of Kenapa-Keppa in Food for Thought
+    local kenapaOvernight = player:getCharVar("Kenapa_Overnight_var") -- progress for Overnight Delivery
+    local kenapaOvernightDay = player:getCharVar("Kenapa_Overnight_Day_var") -- day the quest is started
+    local kenapaOvernightHour = player:getCharVar("Kenapa_Overnight_Hour_var") -- hour the quest is started
     local needToZone = player:needToZone()
     local pFame = player:getFameLevel(WINDURST)
-    local HourOfTheDay = VanadielHour()
+    local vHour = VanadielHour()
 
-    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 4) == false) then
-        player:startEvent(56) -- Show Off Hat
-    elseif ((SayFlowers == QUEST_ACCEPTED or SayFlowers == QUEST_COMPLETED) and FlowerProgress == 2) then
+    if player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 2) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(56)
+    elseif (sayItWithFlowers == QUEST_ACCEPTED or sayItWithFlowers == QUEST_COMPLETED) and flowerProgress == 2 then
         player:startEvent(519)
-    elseif (FoodForThought == QUEST_AVAILABLE) then
+    elseif foodForThought == QUEST_AVAILABLE then
         player:startEvent(310) -- Hungry script
-    elseif (FoodForThought == QUEST_ACCEPTED) then
-        if (KenapaFood == 0) then
+    elseif foodForThought == QUEST_ACCEPTED then
+        if kenapaFood == 0 then
             player:startEvent(318) -- Stammer 1/3
-            player:setCharVar("Kenapa_Food_var", 1)
-        elseif (KenapaFood == 1) then
+        elseif kenapaFood == 1 then
             player:startEvent(319) -- Stammer 2/3
-            player:setCharVar("Kenapa_Food_var", 2)
-        elseif (KenapaFood == 2) then
+        elseif kenapaFood == 2 then
             player:startEvent(320, 0, 4409) -- Gives Order
-            player:setCharVar("Kenapa_Food_var", 3)
-        elseif (FoodForThought == QUEST_ACCEPTED and KenapaFood == 3) then
+        elseif kenapaFood == 3 then
             local rand = math.random(1, 3)
-            if (rand == 1) then
+
+            if rand == 1 then
                 player:startEvent(320, 0, 4409) -- Repeats Order
-            elseif (rand == 2) then
+            elseif rand == 2 then
                 player:startEvent(321) -- "Or Whatever"
             else
                 player:startEvent(328) -- "..<Grin>.."
             end
-        elseif (FoodForThought == QUEST_ACCEPTED and KenapaFood == 4) then -- Give standard conversation options if this NPC has been fed but others haven't
-            local rand = math.random(1, 2)
-            if (rand == 1) then
+        elseif kenapaFood == 4 then -- Give standard conversation options if this NPC has been fed but others haven't
+            if math.random(1, 2) == 1 then
                 player:startEvent(302) -- Standard converstation
             else
                 player:startEvent(303) -- Standard converstation
             end
         end
-    elseif (FoodForThought == QUEST_COMPLETED and OvernightDelivery == QUEST_AVAILABLE and needToZone == false and (HourOfTheDay >= 7 and HourOfTheDay < 24) and pFame >= 1 and KenapaOvernight ~= 256) then
-        if (KenapaOvernight == 0) then
+    elseif
+        foodForThought == QUEST_COMPLETED and
+        overnightDelivery == QUEST_AVAILABLE and
+        not needToZone and
+        vHour >= 7 and vHour < 24 and
+        pFame >= 1 and
+        kenapaOvernight ~= 256
+    then
+        if kenapaOvernight == 0 then
             player:startEvent(336)
-        elseif (KenapaOvernight == 1) then
+        elseif kenapaOvernight == 1 then
             player:startEvent(337)
-        elseif (KenapaOvernight == 2) then
+        elseif kenapaOvernight == 2 then
             player:startEvent(338)
-        elseif (KenapaOvernight == 3) then
+        elseif kenapaOvernight == 3 then
             player:startEvent(339) -- Actual quest acceptance Dialogue
         end
-    elseif (FoodForThought == QUEST_COMPLETED and OvernightDelivery == QUEST_AVAILABLE and KenapaOvernight == 256) then
-        if (HourOfTheDay > 6 and HourOfTheDay < 7) then
+    elseif
+        foodForThought == QUEST_COMPLETED and
+        overnightDelivery == QUEST_AVAILABLE and
+        kenapaOvernight == 256
+    then
+        if vHour > 6 and vHour < 7 then
             player:startEvent(347) -- Failed to return in time; dialogue before quest can be repeated
         else
             player:startEvent(336) -- Restart the quest from the beginning
         end
-    elseif (OvernightDelivery == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.SMALL_BAG) == false) then
-        if (KenapaOvernight == 4) then
+    elseif overnightDelivery == QUEST_ACCEPTED and not player:hasKeyItem(tpz.ki.SMALL_BAG) then
+        if kenapaOvernight == 4 then
             player:startEvent(340) -- Reminder for Overnight Delivery #1
-        elseif (KenapaOvernight == 5) then
+        elseif kenapaOvernight == 5 then
             player:startEvent(341) -- Reminder for Overnight Delivery #2
-        elseif (KenapaOvernight == 6) then
+        elseif kenapaOvernight == 6 then
             player:startEvent(342) -- Reminder for Overnight Delivery #3
-        elseif (KenapaOvernight == 7) then
+        elseif kenapaOvernight == 7 then
             player:startEvent(343) -- Reminder for Overnight Delivery #4
         end
-    elseif (OvernightDelivery == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.SMALL_BAG) == true and (HourOfTheDay <= 6 or HourOfTheDay >= 18)) then
-        if (VanadielDayOfTheYear() == KenapaOvernightDay and (KenapaOvernightHour <= 24 or KenapaOvernightHour < 6)) then
+    elseif
+        overnightDelivery == QUEST_ACCEPTED and
+        player:hasKeyItem(tpz.ki.SMALL_BAG) and
+        (vHour <= 6 or vHour >= 18)
+    then
+        local vDay = VanadielDayOfTheYear()
+
+        if vDay == kenapaOvernightDay and (kenapaOvernightHour <= 24 or kenapaOvernightHour < 6) then
             player:startEvent(348) -- Brought the key item back inside the time frame; got the item and returned it on the same day
-        elseif (VanadielDayOfTheYear() == KenapaOvernightDay + 1 and KenapaOvernightHour <= 24) then
+        elseif vDay == kenapaOvernightDay + 1 and kenapaOvernightHour <= 24 then
             player:startEvent(348) -- Brought the key item back inside the time frame
         else
             player:startEvent(346) -- Failed to return in time
         end
-    elseif (OvernightDelivery == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.SMALL_BAG) == true and HourOfTheDay > 6) then
+    elseif overnightDelivery == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.SMALL_BAG) and vHour > 6 then
         player:startEvent(346) -- Failed to return in time
-    elseif (OvernightDelivery == QUEST_COMPLETED) then
-        local rand = math.random(1, 2)
-        if (rand == 1) then
+    elseif overnightDelivery == QUEST_COMPLETED then
+        if math.random(1, 2) == 1 then
             player:startEvent(349) -- Random comment after Overnight Delivery #1
         else
             player:startEvent(350) -- Random comment after Overnight Delivery #2
         end
     else
-        local rand = math.random(1, 2)
-        if (rand == 1) then
+        if math.random(1, 2) == 1 then
             player:startEvent(302) -- Standard converstation
         else
             player:startEvent(303) -- Standard converstation
@@ -141,63 +152,65 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 327 or csid == 330 or csid == 331) then
-        player:tradeComplete()
-        player:addGil(GIL_RATE*120)
-        if (player:getCharVar("Kerutoto_Food_var") == 2 and player:getCharVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
-            player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT)
-            player:addTitle(tpz.title.FAST_FOOD_DELIVERER)
-            player:addFame(WINDURST, 100)
+    if csid == 327 or csid == 330 or csid == 331 then
+        player:confirmTrade()
+        player:addGil(GIL_RATE * 120)
+        if player:getCharVar("Kerutoto_Food_var") == 2 and player:getCharVar("Ohbiru_Food_var") == 3 then -- last NPC to be fed
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FOOD_FOR_THOUGHT, {
+                title = tpz.title.FAST_FOOD_DELIVERER,
+                fame = 100,
+                var = {"Kerutoto_Food_var", "Kenapa_Food_var", "Ohbiru_Food_var"},
+            })
             player:needToZone(true)
-            player:setCharVar("Kerutoto_Food_var", 0)          -- ------------------------------------------
-            player:setCharVar("Kenapa_Food_var", 0)            -- Erase all the variables used in this quest
-            player:setCharVar("Ohbiru_Food_var", 0)            -- ------------------------------------------
-        else -- If this is NOT the last NPC given food, flag this NPC as completed.
+        else -- not the last NPC given food. flag this NPC as completed.
             player:setCharVar("Kenapa_Food_var", 4)
         end
-    elseif (csid == 56) then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 4)
+    elseif csid == 318 then
+        player:setCharVar("Kenapa_Food_var", 1)
+    elseif csid == 319 then
+        player:setCharVar("Kenapa_Food_var", 2)
+    elseif csid == 320 then
+        player:setCharVar("Kenapa_Food_var", 3)
+    elseif csid == 56 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 2, true))
         player:addCharVar("QuestHatInHand_count", 1)
-    elseif (csid == 336) then
+    elseif csid == 336 then
         player:setCharVar("Kenapa_Overnight_var", 1)
-    elseif (csid == 337) then
+    elseif csid == 337 then
         player:setCharVar("Kenapa_Overnight_var", 2)
-    elseif (csid == 338) then
+    elseif csid == 338 then
         player:setCharVar("Kenapa_Overnight_var", 3)
-    elseif (csid == 339) then
-        if (option == 0) then
+    elseif csid == 339 then
+        if option == 0 then
             player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY)
             player:setCharVar("Kenapa_Overnight_var", 4)
         else
             player:setCharVar("Kenapa_Overnight_var", 0)
         end
-    elseif (csid == 340) then
+    elseif csid == 340 then
         player:setCharVar("Kenapa_Overnight_var", 5)
-    elseif (csid == 341) then
+    elseif csid == 341 then
         player:setCharVar("Kenapa_Overnight_var", 6)
-    elseif (csid == 342) then
+    elseif csid == 342 then
         player:setCharVar("Kenapa_Overnight_var", 7)
-    elseif (csid == 343) then
+    elseif csid == 343 then
         player:setCharVar("Kenapa_Overnight_var", 4) -- Begin reminder sequence
-    elseif (csid == 346) then
+    elseif csid == 346 then
         player:delQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY)
         player:delKeyItem(tpz.ki.SMALL_BAG)
         player:setCharVar("Kenapa_Overnight_Hour_var", 0)
         player:setCharVar("Kenapa_Overnight_var", 256)
-    elseif (csid == 348) then
-        if (player:getFreeSlotsCount() > 0) then
-            player:addItem(12590)
-            player:delKeyItem(tpz.ki.SMALL_BAG)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 12590)
-            player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY)
-            player:addFame(WINDURST, 100)
-            player:needToZone(true)
-            player:setCharVar("Kenapa_Overnight_var", 0)
-            player:setCharVar("Kenapa_Overnight_Hour_var", 0)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12590)
-        end
-    elseif (csid == 519) then
+    elseif
+        csid == 348 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.OVERNIGHT_DELIVERY, {
+            item = 12590, -- power_gi
+            fame = 100,
+            var = {"Kenapa_Overnight_var", "Kenapa_Overnight_Hour_var"},
+        })
+    then
+        player:delKeyItem(tpz.ki.SMALL_BAG)
+        player:needToZone(true)
+    elseif csid == 519 then
         player:setCharVar("FLOWER_PROGRESS", 3)
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
@@ -5,10 +5,11 @@
 -- !pos 27 -6 -199 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
-require("scripts/globals/settings")
 require("scripts/globals/keyitems")
+require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -17,8 +18,8 @@ entity.onTrade = function(player, npc, trade)
     local KenapaFood = player:getCharVar("Kenapa_Food_var") -- Variable to track progress of Kenapa-Keppa in Food for Thought
 
     if (FoodForThought == QUEST_ACCEPTED) then
-        count = trade:getItemCount()
-        gil = trade:getGil()
+        local count = trade:getItemCount()
+        local gil = trade:getGil()
         if (trade:hasItemQty(4409, 1) == false) then -- Traded in wrong item. Not accepted.
             player:startEvent(329)
         elseif (count == 1 and trade:hasItemQty(4409, 1) == true and gil == 0) then
@@ -50,7 +51,7 @@ entity.onTrigger = function(player, npc)
     local pFame = player:getFameLevel(WINDURST)
     local HourOfTheDay = VanadielHour()
 
-    if ((hatstatus == 1 or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 4) == false) then
+    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 4) == false) then
         player:startEvent(56) -- Show Off Hat
     elseif ((SayFlowers == QUEST_ACCEPTED or SayFlowers == QUEST_COMPLETED) and FlowerProgress == 2) then
         player:startEvent(519)
@@ -67,7 +68,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(320, 0, 4409) -- Gives Order
             player:setCharVar("Kenapa_Food_var", 3)
         elseif (FoodForThought == QUEST_ACCEPTED and KenapaFood == 3) then
-            rand = math.random(1, 3)
+            local rand = math.random(1, 3)
             if (rand == 1) then
                 player:startEvent(320, 0, 4409) -- Repeats Order
             elseif (rand == 2) then
@@ -76,7 +77,7 @@ entity.onTrigger = function(player, npc)
                 player:startEvent(328) -- "..<Grin>.."
             end
         elseif (FoodForThought == QUEST_ACCEPTED and KenapaFood == 4) then -- Give standard conversation options if this NPC has been fed but others haven't
-            rand = math.random(1, 2)
+            local rand = math.random(1, 2)
             if (rand == 1) then
                 player:startEvent(302) -- Standard converstation
             else
@@ -120,14 +121,14 @@ entity.onTrigger = function(player, npc)
     elseif (OvernightDelivery == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.SMALL_BAG) == true and HourOfTheDay > 6) then
         player:startEvent(346) -- Failed to return in time
     elseif (OvernightDelivery == QUEST_COMPLETED) then
-        rand = math.random(1, 2)
+        local rand = math.random(1, 2)
         if (rand == 1) then
             player:startEvent(349) -- Random comment after Overnight Delivery #1
         else
             player:startEvent(350) -- Random comment after Overnight Delivery #2
         end
     else
-        rand = math.random(1, 2)
+        local rand = math.random(1, 2)
         if (rand == 1) then
             player:startEvent(302) -- Standard converstation
         else
@@ -154,7 +155,7 @@ entity.onEventFinish = function(player, csid, option)
         else -- If this is NOT the last NPC given food, flag this NPC as completed.
             player:setCharVar("Kenapa_Food_var", 4)
         end
-    elseif  (csid == 56) then  -- Show Off Hat
+    elseif (csid == 56) then  -- Show Off Hat
         player:addCharVar("QuestHatInHand_var", 4)
         player:addCharVar("QuestHatInHand_count", 1)
     elseif (csid == 336) then

--- a/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
@@ -5,9 +5,8 @@
 -- !pos -58 -4 23 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
-require("scripts/globals/settings")
+require("scripts/globals/keyitems")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
@@ -28,9 +27,9 @@ entity.onTrigger = function(player, npc)
         player:startEvent(873)
     elseif (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 14)) then
         player:startEvent(939)
-    elseif ((hatstatus == 1  or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 16) == false) then
+    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 16) == false) then
         player:startEvent(60) -- Show Off Hat
-    elseif (MakingHeadlines == 1) then
+    elseif (MakingHeadlines == QUEST_ACCEPTED) then
         local prog = player:getCharVar("QuestMakingHeadlines_var")
         --  Variable to track if player has talked to 4 NPCs and a door
         --  1 = Kyume

--- a/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kyume-Romeh.lua
@@ -6,6 +6,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
@@ -15,36 +16,28 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
+    local makingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
+    local lureOfTheWildcat = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
+    local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status")==4) then
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 4 then
         player:startEvent(873)
-    elseif (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 14)) then
+    elseif lureOfTheWildcat == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 14) then
         player:startEvent(939)
-    elseif ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 16) == false) then
-        player:startEvent(60) -- Show Off Hat
-    elseif (MakingHeadlines == QUEST_ACCEPTED) then
+    elseif player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 4) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(60)
+    elseif makingHeadlines == QUEST_ACCEPTED then
+        -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
         local prog = player:getCharVar("QuestMakingHeadlines_var")
-        --  Variable to track if player has talked to 4 NPCs and a door
-        --  1 = Kyume
-        -- 2 = Yujuju
-        -- 4 = Hiwom
-        -- 8 = Umumu
-        -- 16 = Mahogany Door
-        if (testflag(tonumber(prog), 1) == false) then
+
+        if not utils.mask.getBit(prog, 0) then
             player:startEvent(668) -- Quest progress
         else
             player:startEvent(669) -- Quest not furthered
         end
     else
-        local rand = math.random(1, 2)
-        if (rand == 1) then
+        if math.random(1, 2) == 1 then
             player:startEvent(604) -- Standard Conversation
         else
             player:startEvent(393) -- Standard Conversation
@@ -56,17 +49,15 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 668) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
-        player:addKeyItem(tpz.ki.WINDURST_WATERS_SCOOP)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WINDURST_WATERS_SCOOP)
-        player:setCharVar("QuestMakingHeadlines_var", prog+1)
-    elseif (csid == 60) then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 16)
+    if csid == 668 then
+        npcUtil.giveKeyItem(player, tpz.ki.WINDURST_WATERS_SCOOP)
+        player:setCharVar("QuestMakingHeadlines_var", utils.mask.setBit(player:getCharVar("QuestMakingHeadlines_var"), 0, true))
+    elseif csid == 60 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 4, true))
         player:addCharVar("QuestHatInHand_count", 1)
-    elseif (csid == 873) then
+    elseif csid == 873 then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 5)
-    elseif (csid == 939) then
+    elseif csid == 939 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 14, true))
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Machitata.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Machitata.lua
@@ -5,10 +5,9 @@
 -- !pos 163 0 -22 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
-require("scripts/globals/settings")
 require("scripts/globals/keyitems")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -19,8 +18,8 @@ entity.onTrigger = function(player, npc)
     function testflag(set, flag)
         return (set % (2*flag) >= flag)
     end
-    hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == 1  or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 1) == false) then
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 1) == false) then
         player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, tpz.ki.NEW_MODEL_HAT)
         player:addCharVar("QuestHatInHand_var", 1)
         player:addCharVar("QuestHatInHand_count", 1)

--- a/scripts/zones/Windurst_Waters/npcs/Machitata.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Machitata.lua
@@ -15,14 +15,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 1) == false) then
-        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, tpz.ki.NEW_MODEL_HAT)
-        player:addCharVar("QuestHatInHand_var", 1)
-        player:addCharVar("QuestHatInHand_count", 1)
+    if player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 0) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(58)
+    else
+        player:startEvent(526)
     end
 end
 
@@ -30,6 +27,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 58 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 0, true))
+        player:addCharVar("QuestHatInHand_count", 1)
+    end
 end
 
 return entity

--- a/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
@@ -5,10 +5,11 @@
 -- !pos -246 -5 -308 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/settings")
 require("scripts/globals/titles")
-require("scripts/globals/keyitems")
 require("scripts/globals/quests")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -31,12 +32,12 @@ entity.onTrigger = function(player, npc)
         return (set % (2*flag) >= flag)
     end
 
-    MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
+    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
 
-    if (MakingHeadlines == 0) then
+    if (MakingHeadlines == QUEST_AVAILABLE) then
         player:startEvent(665) -- Quest Start
-    elseif (MakingHeadlines == 1) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
+    elseif (MakingHeadlines == QUEST_ACCEPTED) then
+        local prog = player:getCharVar("QuestMakingHeadlines_var")
         --     Variable to track if player has talked to 4 NPCs and a door
         --     1 = Kyume
         --    2 = Yujuju
@@ -44,7 +45,7 @@ entity.onTrigger = function(player, npc)
         --    8 = Umumu
         --    16 = Mahogany Door
         if (testflag(tonumber(prog), 1) == false or testflag(tonumber(prog), 2) == false or testflag(tonumber(prog), 4) == false or testflag(tonumber(prog), 8) == false) then
-            rand = math.random(1, 2)
+            local rand = math.random(1, 2)
             if (rand == 1) then
                 player:startEvent(666) -- Quest Reminder 1
             else
@@ -53,10 +54,10 @@ entity.onTrigger = function(player, npc)
         elseif (testflag(tonumber(prog), 8) == true and testflag(tonumber(prog), 16) == false) then
             player:startEvent(673) -- Advises to validate story
         elseif (prog == 31) then
-            rand = math.random(1, 2)
+            local rand = math.random(1, 2)
             if (rand == 1) then
                 player:startEvent(674) -- Quest finish 1
-            elseif (scoop == 4 and door == 1) then
+            else
                 player:startEvent(670)    -- Quest finish 2
             end
         end

--- a/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Naiko-Paneiko.lua
@@ -6,7 +6,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
 require("scripts/globals/keyitems")
-require("scripts/globals/settings")
+require("scripts/globals/npc_util")
 require("scripts/globals/titles")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
@@ -14,79 +14,65 @@ require("scripts/globals/utils")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local ridingOnTheClouds = player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS)
 
-    if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_4") == 2) then
-        if (trade:hasItemQty(1127, 1) and trade:getItemCount() == 1) then -- Trade Kindred seal
-            player:setCharVar("ridingOnTheClouds_4", 0)
-            player:tradeComplete()
-            player:addKeyItem(tpz.ki.SPIRITED_STONE)
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.SPIRITED_STONE)
-        end
+    if
+        ridingOnTheClouds == QUEST_ACCEPTED and
+        player:getCharVar("ridingOnTheClouds_4") == 2 and
+        npcUtil.tradeHas(trade, 1127) -- Kindred seal
+    then
+        player:setCharVar("ridingOnTheClouds_4", 0)
+        player:confirmTrade()
+        npcUtil.giveKeyItem(player, tpz.ki.SPIRITED_STONE)
     end
-
 end
 
 entity.onTrigger = function(player, npc)
+    local makingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
 
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-
-    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-
-    if (MakingHeadlines == QUEST_AVAILABLE) then
-        player:startEvent(665) -- Quest Start
-    elseif (MakingHeadlines == QUEST_ACCEPTED) then
+    if makingHeadlines == QUEST_AVAILABLE then
+        player:startEvent(665)
+    elseif makingHeadlines == QUEST_ACCEPTED then
+        -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
         local prog = player:getCharVar("QuestMakingHeadlines_var")
-        --     Variable to track if player has talked to 4 NPCs and a door
-        --     1 = Kyume
-        --    2 = Yujuju
-        --    4 = Hiwom
-        --    8 = Umumu
-        --    16 = Mahogany Door
-        if (testflag(tonumber(prog), 1) == false or testflag(tonumber(prog), 2) == false or testflag(tonumber(prog), 4) == false or testflag(tonumber(prog), 8) == false) then
-            local rand = math.random(1, 2)
-            if (rand == 1) then
+
+        if not utils.mask.isFull(prog, 4) then
+            if math.random(1, 2) == 1 then
                 player:startEvent(666) -- Quest Reminder 1
             else
                 player:startEvent(671) -- Quest Reminder 2
             end
-        elseif (testflag(tonumber(prog), 8) == true and testflag(tonumber(prog), 16) == false) then
+        elseif not utils.mask.getBit(prog, 4) then
             player:startEvent(673) -- Advises to validate story
-        elseif (prog == 31) then
-            local rand = math.random(1, 2)
-            if (rand == 1) then
+        else
+            if math.random(1, 2) == 1 then
                 player:startEvent(674) -- Quest finish 1
             else
-                player:startEvent(670)    -- Quest finish 2
+                player:startEvent(670) -- Quest finish 2
             end
         end
     else
         player:startEvent(663) -- Standard conversation
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 665) then
+    if csid == 665 then
         player:addQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-    elseif (csid == 670 or csid == 674) then
-        player:addTitle(tpz.title.EDITORS_HATCHET_MAN)
-        player:addGil(GIL_RATE*560)
-        player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*560)
+    elseif csid == 670 or csid == 674 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES, {
+            title = tpz.title.EDITORS_HATCHET_MAN,
+            gil = 560,
+            var = "QuestMakingHeadlines_var",
+        })
         player:delKeyItem(tpz.ki.WINDURST_WOODS_SCOOP)
         player:delKeyItem(tpz.ki.WINDURST_WALLS_SCOOP)
         player:delKeyItem(tpz.ki.WINDURST_WATERS_SCOOP)
         player:delKeyItem(tpz.ki.PORT_WINDURST_SCOOP)
-        player:setCharVar("QuestMakingHeadlines_var", 0)
-        player:addFame(WINDURST, 30)
-        player:completeQuest(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
     end
-
 end
 
 return entity

--- a/scripts/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
@@ -26,14 +26,14 @@ entity.onTrigger = function(player, npc)
         12473,  1863, 2,     --Poet's Circlet
         12499, 14400, 2,     --Flax Headband
         12457,  3272, 2,     --Cotton Hachimaki
-        12454,  3520, 2,     --Bone Mask
         12474, 10924, 2,     --Wool Hat
 
         12464,  1742, 3,     --Headgear
         12456,   552, 3,     --Hachimaki
         12498,  1800, 3,     --Cotton Headband
         12448,   151, 3,     --Bronze Cap
-        12449,  1471, 3      --Brass Cap
+        12449,  1471, 3,     --Brass Cap
+        12543,   690, 3,     --Windshear Hat
     }
     tpz.shop.nation(player, stock, tpz.nation.WINDURST)
 

--- a/scripts/zones/Windurst_Waters/npcs/Pechiru-Mashiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Pechiru-Mashiru.lua
@@ -4,6 +4,8 @@
 -- Involved in Quests: Hat in Hand
 -- !pos 162 -2 159 238
 -----------------------------------
+local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
@@ -13,13 +15,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
-    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 64) == false) then
-        player:startEvent(54) -- Show Off Hat
-    elseif player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED then
+    local makingTheGrade = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE)
+
+    if player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 6) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(54)
+    elseif makingTheGrade == QUEST_ACCEPTED then
         player:startEvent(445)
     else
         player:startEvent(421) -- Standard Conversation
@@ -30,8 +31,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 54) then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 64)
+    if csid == 54 then
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 6, true))
         player:addCharVar("QuestHatInHand_count", 1)
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Pechiru-Mashiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Pechiru-Mashiru.lua
@@ -4,9 +4,8 @@
 -- Involved in Quests: Hat in Hand
 -- !pos 162 -2 159 238
 -----------------------------------
-require("scripts/globals/settings")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
 
@@ -17,8 +16,8 @@ entity.onTrigger = function(player, npc)
     function testflag(set, flag)
         return (set % (2*flag) >= flag)
     end
-    hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
-    if ((hatstatus == 1  or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 64) == false) then
+    local hatstatus = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
+    if ((hatstatus == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 64) == false) then
         player:startEvent(54) -- Show Off Hat
     elseif player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED then
         player:startEvent(445)

--- a/scripts/zones/Windurst_Waters/npcs/Tosuka-Porika.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Tosuka-Porika.lua
@@ -7,12 +7,10 @@
 -- !pos -26 -6 103 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
-require("scripts/globals/titles")
-require("scripts/globals/quests")
-require("scripts/globals/settings")
 require("scripts/globals/keyitems")
-require("scripts/globals/npc_util")
 require("scripts/globals/missions")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
 -----------------------------------
 local entity = {}
 
@@ -59,12 +57,9 @@ entity.onTrigger = function(player, npc)
         end
 
     -- Hat in Hand
-    elseif
-        (player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.HAT_IN_HAND) == QUEST_ACCEPTED or
-        player:getCharVar("QuestHatInHand_var2") == 1) and
-        bit.band(player:getCharVar("QuestHatInHand_var"), bit.lshift(1, 5)) == 0
-    then
-        player:startEvent(55) -- Show Off Hat
+    elseif player:hasKeyItem(tpz.ki.NEW_MODEL_HAT) and not utils.mask.getBit(player:getCharVar("QuestHatInHand_var"), 5) then
+        player:messageSpecial(ID.text.YOU_SHOW_OFF_THE, 0, tpz.ki.NEW_MODEL_HAT)
+        player:startEvent(55)
 
     -- Early Bird Catches the Bookworm
     elseif
@@ -137,7 +132,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- Hat in Hand
     elseif csid == 55 then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 32)
+        player:setCharVar("QuestHatInHand_var", utils.mask.setBit(player:getCharVar("QuestHatInHand_var"), 5, true))
         player:addCharVar("QuestHatInHand_count", 1)
 
     -- Early Bird Catches the Bookworm

--- a/scripts/zones/Windurst_Woods/npcs/Umumu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Umumu.lua
@@ -4,8 +4,8 @@
 --  Involved In Quest: Making Headlines
 -- !pos 32.575 -5.250 141.372 241
 -----------------------------------
-local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/utils")
 -----------------------------------
@@ -15,31 +15,24 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    function testflag(set, flag)
-        return (set % (2*flag) >= flag)
-    end
+    local makingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
+    local lureOfTheWildcat = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
+    local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    local MakingHeadlines = player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 3) then
+    if lureOfTheWildcat == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 3) then
         player:startEvent(731)
-    elseif MakingHeadlines == QUEST_ACCEPTED then
+    elseif makingHeadlines == QUEST_ACCEPTED then
+        -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
         local prog = player:getCharVar("QuestMakingHeadlines_var")
-        -- Variable to track if player has talked to 4 NPCs and a door
-        -- 1 = Kyume
-        -- 2 = Yujuju
-        -- 4 = Hiwom
-        -- 8 = Umumu
-        -- 16 = Mahogany Door
-        if testflag(tonumber(prog), 16) then
+
+        if utils.mask.getBit(prog, 4) then
             player:startEvent(383) -- Advised to go to Naiko
-        elseif not testflag(tonumber(prog), 8) then
+        elseif not utils.mask.getBit(prog, 3) then
             player:startEvent(381) -- Get scoop and asked to validate
         else
             player:startEvent(382) -- Reminded to validate
         end
-    elseif MakingHeadlines == QUEST_COMPLETED then
+    elseif makingHeadlines == QUEST_COMPLETED then
         local rand = math.random(1, 3)
 
         if rand == 1 then
@@ -59,10 +52,8 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 381 then
-        local prog = player:getCharVar("QuestMakingHeadlines_var")
-        player:addKeyItem(tpz.ki.WINDURST_WOODS_SCOOP)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WINDURST_WOODS_SCOOP)
-        player:setCharVar("QuestMakingHeadlines_var", prog+8)
+        npcUtil.giveKeyItem(player, tpz.ki.WINDURST_WOODS_SCOOP)
+        player:setCharVar("QuestMakingHeadlines_var", utils.mask.setBit(player:getCharVar("QuestMakingHeadlines_var"), 3, true))
     elseif csid == 731 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 3, true))
     end

--- a/scripts/zones/Windurst_Woods/npcs/Umumu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Umumu.lua
@@ -5,8 +5,8 @@
 -- !pos 32.575 -5.250 141.372 241
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Woods/IDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
 
     if player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 3) then
         player:startEvent(731)
-    elseif MakingHeadlines == 1 then
+    elseif MakingHeadlines == QUEST_ACCEPTED then
         local prog = player:getCharVar("QuestMakingHeadlines_var")
         -- Variable to track if player has talked to 4 NPCs and a door
         -- 1 = Kyume
@@ -39,7 +39,7 @@ entity.onTrigger = function(player, npc)
         else
             player:startEvent(382) -- Reminded to validate
         end
-    elseif MakingHeadlines == 2 then
+    elseif MakingHeadlines == QUEST_COMPLETED then
         local rand = math.random(1, 3)
 
         if rand == 1 then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Three quests ...

* Making Headlines
* Hat in Hand
* Forge Your Destiny

... were using custom bit-checking function called testflag() that was littered across many NPC scripts.  This PR kills those testflag() functions, and instead uses the functions on utils.mask

I saw a lot of old code and some errors in related NPCs, so I modernizes all the NPC scripts that were involved.  Changes include:

* when clicking on the Mahogany Door during Making Headlines, add a textID for CAT_BURGLARS_HIDEOUT message, rather than a magic number which hadn't been kept current.
* during Hat in Hand, add the "You show off your hat" message for the mandatory NPCs.  Note that Hat in Hand is not retail accurate.  In retail you have to show the hat to nearly every NPC in the zone to get the maximum reward.  But that change is too big for this PR, which was already creeping toward annoying-to-review.
* Hat in Hand is [no longer repeatable](https://ffxiclopedia.fandom.com/wiki/Talk:Hat_in_Hand) (as of Sept 2010) so I removed its repeatability.  Also, the Windshear Hat is [now for sale](https://ffxiclopedia.fandom.com/wiki/Windshear_Hat) at Orez-Ebrez.
* add default dialog to Machitata.
* when completing Hat in Hand, don't rely on option, which can be spoofed, to determine reward for Hat in Hand.  Instead, I'm using player:setLocalVar.
* during Forge Your Destiny, add a missing event param when re-purchasing Sacred Sprig from Ranemaud.
* npcUtil-ify trades and quest completions.

For testing, I did a full run through of all three quests after making these changes.
