### PR TITLE
re-add and reassign groups for battlefield allies

### DIFF
--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -17,11 +17,11 @@ function onBattlefieldInitialise(battlefield)
     local baseID = ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() - 1) * 2
     local pos = GetMobByID(baseID):getSpawnPos()
 
-    local prishe = battlefield:insertEntity(14166, true, true)
+    local prishe = battlefield:insertEntity(11, true, true)
     prishe:setSpawn(pos.x - 6, pos.y, pos.z - 21.5, 192)
     prishe:spawn()
 
-    local selhteus = battlefield:insertEntity(14167, true, true)
+    local selhteus = battlefield:insertEntity(12, true, true)
     selhteus:setSpawn(pos.x + 10, pos.y, pos.z - 17.5, 172)
     selhteus:spawn()
 end

--- a/scripts/zones/Full_Moon_Fountain/Zone.lua
+++ b/scripts/zones/Full_Moon_Fountain/Zone.lua
@@ -69,7 +69,7 @@ function onEventFinish(player, csid, option)
             -- spawn Ajido-Marujido and set ally positions
             local allies = battlefield:getAllies()
             if #allies == 0 then
-                local ajido = battlefield:insertEntity(14184, true, true)
+                local ajido = battlefield:insertEntity(33, true, true)
                 ajido:setSpawn(allyPos[inst].ajidoPos)
                 ajido:spawn()
             end

--- a/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
@@ -13,7 +13,7 @@ end
 
 function onBattlefieldInitialise(battlefield)
 
-    local karababa  = battlefield:insertEntity(2157, true, true)
+    local karababa  = battlefield:insertEntity(8, true, true)
     karababa:setSpawn(360.937, -116.5, 376.937, 0)
     karababa:spawn()
 end

--- a/scripts/zones/QuBia_Arena/Zone.lua
+++ b/scripts/zones/QuBia_Arena/Zone.lua
@@ -49,7 +49,7 @@ function onEventFinish(player, csid, option)
             -- spawn trion and set ally positions
             local allies = battlefield:getAllies()
             if #allies == 0 then
-                local trion = battlefield:insertEntity(14183, true, true)
+                local trion = battlefield:insertEntity(75, true, true)
                 trion:setSpawn(allyPos[inst].trionPos)
                 trion:spawn()
             end

--- a/scripts/zones/Throne_Room/mobs/Zeid.lua
+++ b/scripts/zones/Throne_Room/mobs/Zeid.lua
@@ -31,7 +31,7 @@ function onEventFinish(player, csid, option)
         }
 
         SpawnMob(zeidId + 1)
-        local volker = player:getBattlefield():insertEntity(14182, true, true)
+        local volker = player:getBattlefield():insertEntity(28, true, true)
         player:setPos(unpack(playerCoords[bfid]))
         volker:setSpawn(unpack(volkerCoords[bfid]))
         volker:spawn()

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1353,9 +1353,8 @@ INSERT INTO `mob_groups` VALUES (7,0,36,'Promathia_htbf',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (8,4820,36,'Metus',0,128,0,0,20000,125,125,0);
 INSERT INTO `mob_groups` VALUES (9,0,36,'Omega',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (10,0,36,'Ultima',0,128,0,0,0,0,0,0);
-
-INSERT INTO `mob_groups` VALUES (14166,3199,36,'Prishe',0,128,0,2200,0,75,75,1);
-INSERT INTO `mob_groups` VALUES (14167,5417,36,'Selhteus',0,128,0,0,0,75,75,1);
+INSERT INTO `mob_groups` VALUES (11,3199,36,'Prishe',0,128,0,2200,0,75,75,1); -- ally
+INSERT INTO `mob_groups` VALUES (12,5417,36,'Selhteus',0,128,0,0,0,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Temenos (Zone 37)
@@ -3104,7 +3103,7 @@ INSERT INTO `mob_groups` VALUES (4,2063,64,'Immortal_Flan',0,128,0,0,0,53,53,0);
 INSERT INTO `mob_groups` VALUES (5,3582,64,'Shamarhaan',0,128,0,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (6,4123,64,'Valkeng',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (7,2221,64,'Khimaira_13',0,128,0,0,0,70,70,0);
-INSERT INTO `mob_groups` VALUES (8,2189,64,'Karababa',0,128,0,1000,1000,75,75,1);
+INSERT INTO `mob_groups` VALUES (8,2189,64,'Karababa',0,128,0,1000,1000,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Mamook (Zone 65)
@@ -11091,6 +11090,7 @@ INSERT INTO `mob_groups` VALUES (24,0,165,'Lion',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (25,0,165,'Lion',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (26,0,165,'Zeid',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (27,0,165,'Aldo',0,128,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (28,4249,165,'Volker',0,128,0,0,0,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Ranguemont_Pass (Zone 166)
@@ -11281,6 +11281,7 @@ INSERT INTO `mob_groups` VALUES (29,0,170,'Clone_of_Shadows',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (30,0,170,'Pet_Prime',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (31,0,170,'Fenrir_Prime_HTBF',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (32,0,170,'Carbuncle_Prime_HTBF',0,128,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (33,75,170,'Ajido-Marujido',0,128,0,0,0,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Crawlers_Nest_[S] (Zone 171)
@@ -12983,6 +12984,7 @@ INSERT INTO `mob_groups` VALUES (71,1050,206,'Disfaurit_B_DAurphe',0,128,0,0,0,0
 INSERT INTO `mob_groups` VALUES (72,2147,206,'Jeumouque_B_DAurphe',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (73,0,206,'Ullegore',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (74,0,206,'Mumor',0,128,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (75,4006,206,'Trion',0,128,0,0,0,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Cloister_of_Flames (Zone 207)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

I had removed some of these ally groups during mob QC.  Re-added, and assigned new (low/ordered) groupids.

Relates to #2590 