### PR TITLE
Canary

### DIFF
--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -74,7 +74,9 @@ local ids =
     RETRACE               = 60,
     SOUTHERN_SAN_DORIA_S  = 61,
     BASTOK_MARKETS_S      = 62,
-    WINDURST_WATERS_S     = 63
+    WINDURST_WATERS_S     = 63,
+    ESCHA_ZITAH           = 64,
+    QUFIM_CONFLUENCE      = 65
 }
 tpz.teleport.id = ids
 
@@ -140,7 +142,9 @@ local destinations =
     [ids.ZVAHL_KEEP]            = {-555.996,  -70.100,   59.989,   0, 162},
     [ids.SOUTHERN_SAN_DORIA_S]  = { -98.000,    1.000,  -41.000, 224,  80},
     [ids.BASTOK_MARKETS_S]      = {-291.000,  -10.000, -107.000, 212,  87},
-    [ids.WINDURST_WATERS_S]     = { -31.442,   -5.000,  129.202, 128,  94}
+    [ids.WINDURST_WATERS_S]     = { -31.442,   -5.000,  129.202, 128,  94},
+    [ids.ESCHA_ZITAH]           = {    -338,        6,     -225, 172, 288},
+    [ids.QUFIM_CONFLUENCE]      = {    -203,      -20,       81,  76, 126}
 }
 
 tpz.teleport.type =

--- a/scripts/zones/Escha_RuAun/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Escha_RuAun/npcs/Undulating_Confluence.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Escha - Ru'Aun (289)
+--  NPC: Undulating Confluence
+-- !pos -0.163 -34.106 -471.971 289
+-----------------------------------
+local ID = require("scripts/zones/Escha_ZiTah/IDs")
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(1)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    if csid == 1 and option == 1 then
+        tpz.teleport.to(player, tpz.teleport.id.MISAREAUX_CONFLUENCE)
+    end
+end
+
+return entity

--- a/scripts/zones/Escha_ZiTah/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Escha_ZiTah/npcs/Undulating_Confluence.lua
@@ -19,7 +19,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 4 and option == 1 then
-        player:setPos(-203, -20, 81, 76, 126)
+        tpz.teleport.to(player, tpz.teleport.id.QUFIM_CONFLUENCE)
     end
 end
 

--- a/scripts/zones/Misareaux_Coast/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Undulating_Confluence.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Misareaux Coast (25)
+--  NPC: Undulating Confluence
+-- !pos --48.908 -23.302 572.269 25
+-----------------------------------
+local ID = require("scripts/zones/Misareaux_Coast/IDs")
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(14)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    if csid == 14 and option == 1 then
+        tpz.teleport.to(player, tpz.teleport.id.ESCHA_RUAUN)
+    end
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Qufim_Island/npcs/Undulating_Confluence.lua
@@ -32,9 +32,9 @@ entity.onEventFinish = function(player, csid, option)
         player:completeMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.AT_THE_HEAVENS_DOOR)
         player:addMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.THE_LIONS_ROAR)
     elseif csid == 64 then
-        player:setPos(-338, 6, -225, 172, 288)
+        tpz.teleport.to(player, tpz.teleport.id.ESCHA_ZITAH)
     elseif csid == 65 and option == 1 then
-        player:setPos(-338, 6, -225, 172, 288)
+        tpz.teleport.to(player, tpz.teleport.id.ESCHA_ZITAH)
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x ] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x ] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [ x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
Pushes the teleport locations into globals/teleports for the Undulating Confluences in Qufim Island and Escha Zitah