### PR TITLE
update NPCs involved in AF hands quest

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Yin_Pocanakhu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Yin_Pocanakhu.lua
@@ -10,26 +10,26 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:getCharVar("BorghertzHandsFirstTime") == 2) then
+    if player:getCharVar("BorghertzHandsFirstTime") == 2 then
         player:startEvent(220)
     else
         player:startEvent(209)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    if csid == 220 and player:delGil(1000) then
+        player:setLocalVar("paidYin", 1)
+        player:updateEvent(1)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 220 and option == 0 and player:delGil(1000)) then
-        player:startEvent(221)
+    if csid == 220 and player:getLocalVar("paidYin") == 1 then
+        player:setLocalVar("paidYin", 0)
         player:setCharVar("BorghertzHandsFirstTime", 0)
         player:setCharVar("BorghertzCS", 1)
     end
-
 end
 
 return entity

--- a/scripts/zones/Port_Jeuno/npcs/qm1.lua
+++ b/scripts/zones/Port_Jeuno/npcs/qm1.lua
@@ -4,10 +4,8 @@
 -- Finish Quest: Borghertz's Hands (AF Hands, Many job)
 -- !pos -51 8 -4 246
 -----------------------------------
-local ID = require("scripts/zones/Port_Jeuno/IDs")
-require("scripts/globals/settings")
 require("scripts/globals/keyitems")
-require("scripts/globals/shop")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 -----------------------------------
 local entity = {}
@@ -16,15 +14,15 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    OldGauntlets = player:hasKeyItem(tpz.ki.OLD_GAUNTLETS)
-    ShadowFlames = player:hasKeyItem(tpz.ki.SHADOW_FLAMES)
-    BorghertzCS = player:getCharVar("BorghertzCS")
+    local hasGauntlets = player:hasKeyItem(tpz.ki.OLD_GAUNTLETS)
+    local hasShadowFlames = player:hasKeyItem(tpz.ki.SHADOW_FLAMES)
+    local borghertzCS = player:getCharVar("BorghertzCS")
 
-    if (OldGauntlets == true and ShadowFlames == false and BorghertzCS == 1) then
+    if hasGauntlets and not hasShadowFlames and borghertzCS == 1 then
         player:startEvent(20)
-    elseif (OldGauntlets == true and ShadowFlames == false and BorghertzCS == 2) then
+    elseif hasGauntlets and not hasShadowFlames and borghertzCS == 2 then
         player:startEvent(49)
-    elseif (OldGauntlets == true and ShadowFlames == true) then
+    elseif hasGauntlets and hasShadowFlames then
         player:startEvent(48)
     end
 end
@@ -33,22 +31,21 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 20 and option == 1) then
+    if csid == 20 and option == 1 then
         player:setCharVar("BorghertzCS", 2)
-    elseif (csid == 48) then
-        NumQuest = tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + player:getCharVar("BorghertzAlreadyActiveWithJob") - 1
-        NumHands = 13960 + player:getCharVar("BorghertzAlreadyActiveWithJob")
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, NumHands)
-        else
-            player:addItem(NumHands)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, NumHands)
+    elseif csid == 48 then
+        local questJob = player:getCharVar("BorghertzAlreadyActiveWithJob")
+        local quest = tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + questJob - 1
+        local reward = 13960 + questJob
+
+        if
+            npcUtil.completeQuest(player, JEUNO, quest, {
+                item = reward,
+                var = {"BorghertzCS", "BorghertzAlreadyActiveWithJob"},
+            })
+        then
             player:delKeyItem(tpz.ki.OLD_GAUNTLETS)
             player:delKeyItem(tpz.ki.SHADOW_FLAMES)
-            player:setCharVar("BorghertzCS", 0)
-            player:setCharVar("BorghertzAlreadyActiveWithJob", 0)
-            player:addFame(JEUNO, 30)
-            player:completeQuest(tpz.quest.log_id.JEUNO, NumQuest)
         end
     end
 end

--- a/scripts/zones/Upper_Jeuno/npcs/Deadly_Minnow.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Deadly_Minnow.lua
@@ -17,7 +17,6 @@ entity.onTrigger = function(player, npc)
 
     if player:getCharVar("BorghertzHandsFirstTime") == 1 then
         player:startEvent(24)
-        player:setCharVar("BorghertzHandsFirstTime", 2)
     else
         local stock =
         {
@@ -42,6 +41,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 24 then
+        player:setCharVar("BorghertzHandsFirstTime", 2)
+    end
 end
 
 return entity

--- a/scripts/zones/Upper_Jeuno/npcs/Guslam.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Guslam.lua
@@ -4,174 +4,91 @@
 -- Starts Quest: Borghertz's Hands (AF Hands, Many job)
 -- !pos -5 1 48 244
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/settings")
 require("scripts/globals/keyitems")
 require("scripts/globals/quests")
+require("scripts/globals/status")
 -----------------------------------
 local entity = {}
+
+local prerequisites =
+{
+    [tpz.job.WAR] = { log = tpz.quest.log_id.BASTOK,   quest = tpz.quest.id.bastok.THE_TALEKEEPER_S_TRUTH       },
+    [tpz.job.MNK] = { log = tpz.quest.log_id.BASTOK,   quest = tpz.quest.id.bastok.THE_FIRST_MEETING            },
+    [tpz.job.WHM] = { log = tpz.quest.log_id.SANDORIA, quest = tpz.quest.id.sandoria.PRELUDE_OF_BLACK_AND_WHITE },
+    [tpz.job.BLM] = { log = tpz.quest.log_id.WINDURST, quest = tpz.quest.id.windurst.RECOLLECTIONS              },
+    [tpz.job.RDM] = { log = tpz.quest.log_id.SANDORIA, quest = tpz.quest.id.sandoria.ENVELOPED_IN_DARKNESS      },
+    [tpz.job.THF] = { log = tpz.quest.log_id.WINDURST, quest = tpz.quest.id.windurst.AS_THICK_AS_THIEVES        },
+    [tpz.job.PLD] = { log = tpz.quest.log_id.SANDORIA, quest = tpz.quest.id.sandoria.A_BOY_S_DREAM              },
+    [tpz.job.DRK] = { log = tpz.quest.log_id.BASTOK,   quest = tpz.quest.id.bastok.DARK_PUPPET                  },
+    [tpz.job.BST] = { log = tpz.quest.log_id.JEUNO,    quest = tpz.quest.id.jeuno.SCATTERED_INTO_SHADOW         },
+    [tpz.job.BRD] = { log = tpz.quest.log_id.JEUNO,    quest = tpz.quest.id.jeuno.THE_REQUIEM                   },
+    [tpz.job.RNG] = { log = tpz.quest.log_id.WINDURST, quest = tpz.quest.id.windurst.FIRE_AND_BRIMSTONE         },
+    [tpz.job.SAM] = { log = tpz.quest.log_id.OUTLANDS, quest = tpz.quest.id.outlands.YOMI_OKURI                 },
+    [tpz.job.NIN] = { log = tpz.quest.log_id.OUTLANDS, quest = tpz.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX      },
+    [tpz.job.DRG] = { log = tpz.quest.log_id.SANDORIA, quest = tpz.quest.id.sandoria.CHASING_QUOTAS             },
+    [tpz.job.SMN] = { log = tpz.quest.log_id.WINDURST, quest = tpz.quest.id.windurst.CLASS_REUNION              },
+}
+
+local function isFirstHandsQuest(player)
+    local count = 0
+
+    for i = 0, 14 do
+        if player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + i) == QUEST_COMPLETED then
+            return false
+        end
+    end
+
+    return true
+end
+
 
 entity.onTrade = function(player, npc, trade)
 end
 
--- If it's the first Hands quest
-local function nbHandsQuestsCompleted(player)
-
-    local questNotAvailable = 0
-
-    for nb = 0, 14, 1 do
-        if (player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + nb) ~= QUEST_AVAILABLE) then
-            questNotAvailable = questNotAvailable + 1
-        end
-    end
-
-    return questNotAvailable
-
-end
-
 entity.onTrigger = function(player, npc)
-    -- TODO: table this stuff, rather than tall if-elseif
-    if (player:getMainLvl() >= 50 and player:getCharVar("BorghertzAlreadyActiveWithJob") == 0) then
-        if
-            player:getMainJob() == tpz.job.WAR and
-            player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.THE_TALEKEEPER_S_TRUTH) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for WAR
+    local mJob = player:getMainJob()
+    local prereq = prerequisites[mJob]
 
-        elseif
-            player:getMainJob() == tpz.job.MNK and
-            player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.THE_FIRST_MEETING) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_STRIKING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for MNK
+    -- HANDS QUEST
+    if
+        prereq and
+        player:getMainLvl() >= 50 and
+        player:getCharVar("BorghertzAlreadyActiveWithJob") == 0 and
+        player:getQuestStatus(prereq.log, prereq.quest) ~= QUEST_AVAILABLE and
+        player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + mJob - 1) == QUEST_AVAILABLE
+    then
+        player:startEvent(155)
+    elseif player:getCharVar("BorghertzAlreadyActiveWithJob") >= 1 and not player:hasKeyItem(tpz.ki.OLD_GAUNTLETS) then
+        player:startEvent(43)
+    elseif player:hasKeyItem(tpz.ki.OLD_GAUNTLETS) then
+        player:startEvent(26)
 
-        elseif
-            player:getMainJob() == tpz.job.WHM and
-            player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.PRELUDE_OF_BLACK_AND_WHITE) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_HEALING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for WHM
-
-        elseif
-            player:getMainJob() == tpz.job.BLM and
-            player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.RECOLLECTIONS) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_SORCEROUS_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for BLM
-
-        elseif
-            player:getMainJob() == tpz.job.RDM and
-            player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.ENVELOPED_IN_DARKNESS) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_VERMILLION_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for RDM
-
-        elseif
-            player:getMainJob() == tpz.job.THF and
-            player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_SNEAKY_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for THF
-
-        elseif
-            player:getMainJob() == tpz.job.PLD and
-            player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.A_BOY_S_DREAM) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_STALWART_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for PLD
-
-        elseif
-            player:getMainJob() == tpz.job.DRK and
-            player:getQuestStatus(tpz.quest.log_id.BASTOK, tpz.quest.id.bastok.DARK_PUPPET) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_SHADOWY_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for DRK
-
-        elseif
-            player:getMainJob() == tpz.job.BST and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.SCATTERED_INTO_SHADOW) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WILD_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for BST
-
-        elseif
-            player:getMainJob() == tpz.job.BRD and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.THE_REQUIEM) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_HARMONIOUS_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for BRD
-
-        elseif
-            player:getMainJob() == tpz.job.RNG and
-            player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.FIRE_AND_BRIMSTONE) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_CHASING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for RNG
-
-        elseif
-            player:getMainJob() == tpz.job.SAM and
-            player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.YOMI_OKURI) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_LOYAL_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for SAM
-
-        elseif
-            player:getMainJob() == tpz.job.NIN and
-            player:getQuestStatus(tpz.quest.log_id.OUTLANDS, tpz.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_LURKING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for NIN
-
-        elseif
-            player:getMainJob() == tpz.job.DRG and
-            player:getQuestStatus(tpz.quest.log_id.SANDORIA, tpz.quest.id.sandoria.CHASING_QUOTAS) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_DRAGON_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for DRG
-
-        elseif
-            player:getMainJob() == tpz.job.SMN and
-            player:getQuestStatus(tpz.quest.log_id.WINDURST, tpz.quest.id.windurst.CLASS_REUNION) ~= QUEST_AVAILABLE and
-            player:getQuestStatus(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_CALLING_HANDS) == QUEST_AVAILABLE
-        then
-            player:startEvent(155) -- Start Quest for SMN
-
-        else
-            player:startEvent(154) -- Standard dialog
+        if player:getCharVar("BorghertzCS") == 0 then
+            if isFirstHandsQuest(player) then
+                if player:getCharVar("BorghertzHandsFirstTime") == 0 then
+                    player:setCharVar("BorghertzHandsFirstTime", 1)
+                end
+            else
+                player:setCharVar("BorghertzCS", 1)
+            end
         end
-    elseif (player:getCharVar("BorghertzAlreadyActiveWithJob") >= 1 and player:hasKeyItem(tpz.ki.OLD_GAUNTLETS) == false) then
-        player:startEvent(43) -- During Quest before KI obtained
-    elseif (player:hasKeyItem(tpz.ki.OLD_GAUNTLETS) == true) then
-        player:startEvent(26) -- Dialog with Old Gauntlets KI
 
-        if (nbHandsQuestsCompleted(player) == 1) then
-            player:setCharVar("BorghertzHandsFirstTime", 1)
-        else
-            player:setCharVar("BorghertzCS", 1)
-        end
+    -- DEFAULT DIALOG
     else
-        player:startEvent(154) -- Standard dialog
+        player:startEvent(154)
     end
-
 end
 
--- 154 Standard dialog
--- 155 Start Quest
--- 43 During Quest before KI obtained
--- 26 Dialog avec Old Gauntlets KI
--- 156 During Quest after Old Gauntlets KI ?
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 155 then
+        local mJob = player:getMainJob()
 
-    if (csid == 155) then
-        local NumQuest = tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + player:getMainJob() - 1
-        player:addQuest(tpz.quest.log_id.JEUNO, NumQuest)
-        player:setCharVar("BorghertzAlreadyActiveWithJob", player:getMainJob())
+        player:addQuest(tpz.quest.log_id.JEUNO, tpz.quest.id.jeuno.BORGHERTZ_S_WARRING_HANDS + mJob - 1)
+        player:setCharVar("BorghertzAlreadyActiveWithJob", mJob)
     end
-
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [x] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work

Guslam:
    * Table prerequisite quest info.
    * Remove if/elseif tower.
    * Don't allow BorghertzHandsFirstTime variable to be set again after it's been zeroed-out.

Yin Pocanakhu:
    * Add onEventUpdate to handle whether the player can pay or not.
    * Stop chaining event 221.
