### PR TITLE
Add mounts up to Feb 2021 update

### DIFF
--- a/scripts/commands/mount.lua
+++ b/scripts/commands/mount.lua
@@ -20,7 +20,7 @@ function onTrigger(player, mount, target)
 
     -- validate mount
     mount = tonumber(mount) or tpz.mount[string.upper(mount)]
-    if (mount == nil or mount < 0 or mount > 27) then
+    if (mount == nil or mount < 0 or mount > 30) then
         error(player, "Invalid mount ID.")
         return
     end

--- a/scripts/globals/keyitems.lua
+++ b/scripts/globals/keyitems.lua
@@ -2989,6 +2989,10 @@ tpz.keyItem =
     ADAMANTOISE_COMPANION                    = 3096,
     DHAMEL_COMPANION                         = 3097,
     DOLL_COMPANION                           = 3098,
+    GOLDEN_BOMB_COMPANION                    = 3099,
+    BUFFALO_COMPANION                        = 3100,
+    WIVRE_COMPANION                          = 3101,
+
     SHEET_OF_SHADOW_LORD_TUNES               = 3136,
     MYSTICAL_CANTEEN                         = 3137,
     YGNASS_INSIGNIA                          = 3138,

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2739,6 +2739,9 @@ tpz.mount =
     ADAMANTOISE    = 25,
     DHAMEL         = 26,
     DOLL           = 27,
+    GOLDEN_BOMB    = 28,
+    BUFFALO        = 29,
+    WIVRE          = 30,
 }
 
 -----------------------------------

--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player,npc,trade)
         if item == 15533 then
             player:startEvent(10227, 15533, tpz.ki.TRAINERS_WHISTLE, tpz.mount.CHOCOBO)
             player:setLocalVar("FullSpeedAheadReward", tpz.ki.CHOCOBO_COMPANION)
-        elseif mount >= 0 and mount <= 24 then
+        elseif mount >= 0 and mount <= 30 then
             player:setLocalVar("FullSpeedAheadReward", tpz.ki.TIGER_COMPANION + mount)
             player:startEvent(10227, item, tpz.ki.TRAINERS_WHISTLE, tpz.mount.TIGER + mount - 1)
         end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

TODO: Check to see if I can replace the hard-coded `30` with `#tpz.mounts` 
TODO: Test the 24 I've changed to 30 isn't meant to have a -3 offset for Chocobo, Raptor and Quest raptor