### PR TITLE
[lua cleanup] shattered telepoints

### DIFF
--- a/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
@@ -14,8 +14,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local rovMission = player:getCurrentMission(ROV)
+    local copMission = player:getCurrentMission(COP)
+
     -- RoV Missions
-    if player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
         player:startEvent(3)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, 10159) then -- Cipher: Lion II
@@ -24,16 +27,19 @@ entity.onTrigger = function(player, npc)
             player:addMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.FATES_CALL)
             player:setCharVar("LionIICipher", 0)
         end
-    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
+    elseif rovMission == tpz.mission.id.rov.A_LAND_AFTER_TIME then
         local rank6 = (player:getRank(player:getNation()) >= 6) and 1 or 0
         player:startEvent(4, player:getZoneID(), 0, 0, 0, 0, 0, rank6)
 
     -- CoP Missions
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
+    elseif copMission == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(913, 0, 0, 1) -- first time in promy -> have you made your preparations cs
     elseif
-        player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and
-        (player:hasKeyItem(tpz.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(tpz.ki.LIGHT_OF_MEA))
+        copMission == tpz.mission.id.cop.THE_MOTHERCRYSTALS and
+        (
+            player:hasKeyItem(tpz.ki.LIGHT_OF_HOLLA) or
+            player:hasKeyItem(tpz.ki.LIGHT_OF_MEA)
+        )
     then
         if player:getCharVar("cspromy2") == 1 then
             player:startEvent(912)  -- cs you get nearing second promyvion
@@ -41,9 +47,12 @@ entity.onTrigger = function(player, npc)
             player:startEvent(913)
         end
     elseif
-        player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or
+        copMission > tpz.mission.id.cop.THE_MOTHERCRYSTALS or
         player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_LAST_VERSE) or
-        (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1)
+        (
+            copMission == tpz.mission.id.cop.BELOW_THE_ARKS and
+            player:getCharVar("PromathiaStatus") > 1
+        )
     then
         player:startEvent(913) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
 

--- a/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
@@ -14,8 +14,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local rovMission = player:getCurrentMission(ROV)
+    local copMission = player:getCurrentMission(COP)
+
     -- RoV Missions
-    if player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
         player:startEvent(14)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, 10159) then -- Cipher: Lion II
@@ -24,27 +27,39 @@ entity.onTrigger = function(player, npc)
             player:addMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.FATES_CALL)
             player:setCharVar("LionIICipher", 0)
         end
-    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
+    elseif rovMission == tpz.mission.id.rov.A_LAND_AFTER_TIME then
         local rank6 = (player:getRank(player:getNation()) >= 6) and 1 or 0
         player:startEvent(15, player:getZoneID(), 0, 0, 0, 0, 0, rank6)
 
     -- CoP Missions
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1) then
+    elseif copMission == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(202, 0, 0, 1) -- first time in promy -> have you made your preparations cs
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and (player:hasKeyItem(tpz.ki.LIGHT_OF_MEA) or player:hasKeyItem(tpz.ki.LIGHT_OF_DEM))) then
-        if (player:getCharVar("cspromy2") == 1) then
-            player:startEvent(201)  -- cs you get nearing second promyvion
+    elseif
+        copMission == tpz.mission.id.cop.THE_MOTHERCRYSTALS and
+        (
+            player:hasKeyItem(tpz.ki.LIGHT_OF_MEA) or
+            player:hasKeyItem(tpz.ki.LIGHT_OF_DEM)
+        )
+    then
+        if player:getCharVar("cspromy2") == 1 then
+            player:startEvent(201) -- cs you get nearing second promyvion
         else
             player:startEvent(202)
         end
-    elseif player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or player:hasCompletedMission(tpz.mission.log_id.COP,tpz.mission.id.cop.THE_LAST_VERSE) or (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1) then
+    elseif
+        copMission > tpz.mission.id.cop.THE_MOTHERCRYSTALS or
+        player:hasCompletedMission(tpz.mission.log_id.COP,tpz.mission.id.cop.THE_LAST_VERSE) or
+        (
+            copMission == tpz.mission.id.cop.BELOW_THE_ARKS and
+            player:getCharVar("PromathiaStatus") > 1
+        )
+    then
         player:startEvent(202) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
 
     -- Default Message
     else
         player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
@@ -65,14 +80,13 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- CoP Missions
-    elseif (csid == 201) then
+    elseif csid == 201 then
         player:setCharVar("cspromy2", 0)
         player:setCharVar("cs2ndpromy", 1)
         player:setPos(92.033, 0, 80.380, 255, 16) -- To Promyvion Holla
-    elseif (csid == 202 and option == 0) then
+    elseif csid == 202 and option == 0 then
         player:setPos(-266.76, -0.635, 280.058, 0, 14) -- To Hall of Transference {R}
     end
-
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
@@ -14,8 +14,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local rovMission = player:getCurrentMission(ROV)
+    local copMission = player:getCurrentMission(COP)
+
     -- RoV Missions
-    if  player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
         player:startEvent(41)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, 10159) then -- Cipher: Lion II
@@ -24,27 +27,39 @@ entity.onTrigger = function(player, npc)
             player:addMission(tpz.mission.log_id.ROV, tpz.mission.id.rov.FATES_CALL)
             player:setCharVar("LionIICipher", 0)
         end
-    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
+    elseif rovMission == tpz.mission.id.rov.A_LAND_AFTER_TIME then
         local rank6 = (player:getRank(player:getNation()) >= 6) and 1 or 0
         player:startEvent(42, player:getZoneID(), 0, 0, 0, 0, 0, rank6)
 
     -- CoP Missions
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
+    elseif copMission == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(913, 0, 0, 1) -- first time in promy -> have you made your preparations cs
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and (player:hasKeyItem(tpz.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(tpz.ki.LIGHT_OF_DEM)) then
+    elseif
+        copMission == tpz.mission.id.cop.THE_MOTHERCRYSTALS and
+        (
+            player:hasKeyItem(tpz.ki.LIGHT_OF_HOLLA) or
+            player:hasKeyItem(tpz.ki.LIGHT_OF_DEM)
+        )
+    then
         if player:getCharVar("cspromy2") == 1 then
             player:startEvent(912)  -- cs you get nearing second promyvion
         else
             player:startEvent(913)
         end
-    elseif player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_LAST_VERSE) or (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1) then
+    elseif
+        copMission > tpz.mission.id.cop.THE_MOTHERCRYSTALS or
+        player:hasCompletedMission(tpz.mission.log_id.COP, tpz.mission.id.cop.THE_LAST_VERSE) or
+        (
+            copMission == tpz.mission.id.cop.BELOW_THE_ARKS and
+            player:getCharVar("PromathiaStatus") > 1
+        )
+    then
         player:startEvent(913) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
 
     -- Default Message
     else
         player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Format some long lines.
Prevent hitting getCurrentMission binding multiple times; no other logic changes.
