### PR TITLE
Bugfix - PartyDefine packet not send if the party leader is in a zone…

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -779,10 +779,7 @@ void CParty::ReloadParty()
             PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->ReloadPartyDec();
-            if (PLeader)
-            {
-                PChar->pushPacket(new CPartyDefinePacket(this, PChar->getZone() == PLeader->getZone()));
-            }
+            PChar->pushPacket(new CPartyDefinePacket(this, PLeader && PChar->getZone() == PLeader->getZone()));
             // auto effects = std::make_unique<CPartyEffectsPacket>();
             uint8 j = 0;
             for (auto&& memberinfo : info)


### PR DESCRIPTION
If the server is clustered and the party leader is in a zone on a different cluster than a party member, the CPartyDefinePacket is not sent to that member, resulting in the party list not showing up an the member cannot send messages in the party chat (but can receive messages) until they zone into the same cluster as the leader (or vice versa).

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
