### PR TITLE
Corrected issue topaz Next #2663 and local issue #1

### DIFF
--- a/scripts/globals/mobskills/cyclone_wing.lua
+++ b/scripts/globals/mobskills/cyclone_wing.lua
@@ -8,7 +8,6 @@
 -- Notes: Used only by Vrtra and Azdaja
 -----------------------------------
 require("scripts/globals/monstertpmoves")
-require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
 local mobskill_object = {}
@@ -23,14 +22,13 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = tpz.effect.SLEEP_I
-
-    MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
-
+    
     local dmgmod = 1
     local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg()*5, tpz.magic.ele.DARK, dmgmod, TP_NO_EFFECT)
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.DARK, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, tpz.attackType.MAGICAL, tpz.damageType.DARK)
+	
+	MobStatusEffectMove(mob, target, tpz.effect.SLEEP_I, 1, 0, 60)
     return dmg
 end
 

--- a/scripts/globals/mobskills/kartstrahl.lua
+++ b/scripts/globals/mobskills/kartstrahl.lua
@@ -6,7 +6,6 @@
 --
 -----------------------------------
 require("scripts/globals/monstertpmoves")
-require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
 local mobskill_object = {}
@@ -21,12 +20,10 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.5
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT, info.hitslanded)
-
-    local typeEffect = tpz.effect.SLEEP_I
-
-    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
-
-    target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT)
+	target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT)
+	
+	MobPhysicalStatusEffectMove(mob, target, skill, tpz.effect.SLEEP_I, 1, 0, 30)
+	
     return dmg
 end
 

--- a/scripts/globals/mobskills/pinecone_bomb.lua
+++ b/scripts/globals/mobskills/pinecone_bomb.lua
@@ -5,7 +5,6 @@
 --
 --
 -----------------------------------
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/monstertpmoves")
 -----------------------------------
@@ -20,14 +19,12 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local accmod = 1
     local dmgmod = 2.3
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
-
+	
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.PIERCING, info.hitslanded)
+target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.PIERCING)
+    
+    MobPhysicalStatusEffectMove(mob, target, skill, tpz.effect.SLEEP_I, 1, 0, 30)
 
-    local typeEffect = tpz.effect.SLEEP_I
-
-    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
-
-    target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.PIERCING)
     return dmg
 end
 

--- a/scripts/globals/mobskills/sweet_breath.lua
+++ b/scripts/globals/mobskills/sweet_breath.lua
@@ -5,7 +5,6 @@
 --  Type: Magical Water (Element)
 --
 -----------------------------------
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/monstertpmoves")
 -----------------------------------
@@ -16,12 +15,11 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = tpz.effect.SLEEP_I
-    MobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
-
     local dmgmod = MobBreathMove(mob, target, 0.125, 3, tpz.magic.ele.WATER, 500)
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.WATER, MOBPARAM_IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, tpz.attackType.BREATH, tpz.damageType.WATER)
+
+	MobStatusEffectMove(mob, target, tpz.effect.SLEEP_I, 1, 0, 30)
 
     return dmg
 end


### PR DESCRIPTION
these 4 mobskills now correctly apply sleep
	after damage is dealt instead of before

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
