### PR TITLE
Add logic for obtaining Prishe Statue I

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Treasure_Coffer.lua
@@ -1,24 +1,28 @@
 -----------------------------------
 -- Area: Port Jeuno
 --  NPC: Treasure Coffer
--- !pos  -52 0 -11 246
+-- !pos -52 0 -11 246
 -----------------------------------
 local ID = require("scripts/zones/Port_Jeuno/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/settings")
 -----------------------------------
 local entity = {}
 
-entity.onTrade = function(player, npc, trade)
-end
+local PRISHE_STATUE = 277
 
 entity.onTrigger = function(player, npc)
-
-    player:messageSpecial(ID.text.CHEST_IS_EMPTY)
-end
-
-entity.onEventUpdate = function(player, csid, option)
+    if ENABLE_ABYSSEA == 1 and not player:hasItem(PRISHE_STATUE) then
+        player:startEvent(350, 0xFFFFFFFC)
+    else
+        player:messageSpecial(ID.text.CHEST_IS_EMPTY)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 350 and option == 2 then
+        npcUtil.giveItem(player, PRISHE_STATUE)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

<https://ffxiclopedia.fandom.com/wiki/Prishe_Statue>

Just for funsies!

Interestingly, the preview for the item doesn't show up for me, but shows for Claywar using the exact same arguments from captures... 🤷 