### PR TITLE
Fixed Pandemonium Warden error preventing phase change

### DIFF
--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
@@ -76,6 +76,17 @@ entity.onMobEngaged = function(mob, target)
     end
 end
 
+local function handlePet(mob, newPet, oldPet, target, modelId)
+
+    if oldPet:isSpawned() then
+        DespawnMob(oldPet:getID())
+    end
+    newPet:setModelId(modelId)
+    newPet:spawn()
+    newPet:setPos(mob:getXPos() + math.random(-2, 2), mob:getYPos(), mob:getZPos() + math.random(-2, 2))
+    newPet:updateEnmity(target)
+end
+
 entity.onMobFight = function(mob, target)
 
     -- Init Vars
@@ -183,17 +194,6 @@ entity.onMobDespawn = function(mob)
             end
         end
     end
-end
-
-local function handlePet(mob, newPet, oldPet, target, modelId)
-
-    if oldPet:isSpawned() then
-        DespawnMob(oldPet:getID())
-    end
-    newPet:setModelId(modelId)
-    newPet:spawn()
-    newPet:setPos(mob:getXPos() + math.random(-2, 2), mob:getYPos(), mob:getZPos() + math.random(-2, 2))
-    newPet:updateEnmity(target)
 end
 
 return entity


### PR DESCRIPTION
…a local function below call site, moved above. 
Recent changes with lua/sol appear to have caused handlePet() to be nil when it is called from onMobFight(), causing it to error and terminate early before it can switch phases. Simple fix, just move it higher in the file.

**_I affirm:_**
[x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
[x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
[x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
