### PR TITLE
Fix The Black Coffin instance in party

### DIFF
--- a/scripts/zones/Arrapago_Reef/Zone.lua
+++ b/scripts/zones/Arrapago_Reef/Zone.lua
@@ -46,13 +46,13 @@ zone_object.afterZoneIn = function(player)
 end
 
 zone_object.onRegionEnter = function(player, region)
-    if (player:getCurrentMission(TOAU) == tpz.mission.id.toau.THE_BLACK_COFFIN and player:hasKeyItem(tpz.ki.EPHRAMADIAN_GOLD_COIN) and player:getCharVar("AhtUrganStatus") == 0) then
+    if player:getCurrentMission(TOAU) == tpz.mission.id.toau.THE_BLACK_COFFIN and player:hasKeyItem(tpz.ki.EPHRAMADIAN_GOLD_COIN) and player:getCharVar("AhtUrganStatus") == 0 then
         player:startEvent(8)
-    elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.PREVALENCE_OF_PIRATES and player:getCharVar("AhtUrganStatus") == 1) then
+    elseif player:getCurrentMission(TOAU) == tpz.mission.id.toau.PREVALENCE_OF_PIRATES and player:getCharVar("AhtUrganStatus") == 1 then
         player:startEvent(14)
-    elseif (player:getCurrentMission(TOAU) == tpz.mission.id.toau.TESTING_THE_WATERS and player:hasKeyItem(tpz.ki.EPHRAMADIAN_GOLD_COIN)) then
+    elseif player:getCurrentMission(TOAU) == tpz.mission.id.toau.TESTING_THE_WATERS and player:hasKeyItem(tpz.ki.EPHRAMADIAN_GOLD_COIN) then
         player:startEvent(15)
-    elseif (player:getQuestStatus(tpz.quest.log_id.AHT_URHGAN, tpz.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) == QUEST_ACCEPTED and player:getCharVar("AgainstAllOdds") == 1) then
+    elseif player:getQuestStatus(tpz.quest.log_id.AHT_URHGAN, tpz.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) == QUEST_ACCEPTED and player:getCharVar("AgainstAllOdds") == 1 then
         player:startEvent(237)
     end
 end
@@ -61,34 +61,34 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if (csid == 8) then
+    if csid == 8 then
         player:setCharVar("AhtUrganStatus", 1)
         player:startEvent(34, 1, 1, 1, 1, 1, 1, 1, 1)
-    elseif (csid == 9) then
+    elseif csid == 9 then
         player:setCharVar("AhtUrganStatus", 3)
         player:setPos(0, 0, 0, 0, 53)
-    elseif (csid == 13) then
+    elseif csid == 13 then
         player:setCharVar("AhtUrganStatus", 1)
-    elseif (csid == 14) then
+    elseif csid == 14 then
         player:completeMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.PREVALENCE_OF_PIRATES)
         player:setCharVar("AhtUrganStatus", 0)
         player:addKeyItem(tpz.ki.PERIQIA_ASSAULT_AREA_ENTRY_PERMIT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PERIQIA_ASSAULT_AREA_ENTRY_PERMIT)
         player:addMission(tpz.mission.log_id.TOAU, tpz.mission.id.toau.SHADES_OF_VENGEANCE)
-    elseif (csid == 15) then
+    elseif csid == 15 then
         player:setCharVar("AhtUrganStatus", 1)
         player:setPos(0, 0, 0, 0, 57)
-    elseif (csid == 34 and player:getCharVar("AhtUrganStatus") == 1) then
+    elseif csid == 34 and player:getCharVar("AhtUrganStatus") == 1 then
         player:startEvent(35)
-    elseif (csid == 90) then -- enter instance: the ashu talif
-        player:setPos(0, 0, 0, 0, 60)
-    elseif (csid == 108) then -- enter instance: illrusi atoll
+    elseif csid == 108 then -- enter instance: illrusi atoll
         player:setPos(0, 0, 0, 0, 55)
-    elseif (csid == 237) then
+    elseif csid == 222 then -- Enter instance: Black coffin
+        player:setPos(0, 0, 0, 0, 60)
+    elseif csid == 237 then
         player:startEvent(240)
     elseif csid == 238 then
         npcUtil.completeQuest(player, AHT_URHGAN, tpz.quest.id.ahtUrhgan.AGAINST_ALL_ODDS, { item=15266, var="AgainstAllOdds"})
-    elseif (csid == 240) then
+    elseif csid == 240 then
         player:setCharVar("AgainstAllOdds", 2)
     end
 end

--- a/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
@@ -46,7 +46,7 @@ entity.onEventUpdate = function(player, csid, option, target)
         player:createInstance(53, 60)
         player:setLocalVar("theblackcoffinfight", 0)
 
-        elseif player:getLocalVar("againstalloddsfight") == 1 then
+    elseif player:getLocalVar("againstalloddsfight") == 1 then
         if (party ~= nil) then
             for i, v in pairs(party) do
                 if v:getZoneID() == player:getZoneID() and v:checkDistance(player) > 50 then
@@ -63,23 +63,29 @@ entity.onEventUpdate = function(player, csid, option, target)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 221 and option == 4) or csid == 90 then
+    if csid == 221 and option == 4 then
+        local party = player:getParty()
+        if (party ~= nil) then
+            for i, v in pairs(party) do
+                if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
+                    v:startEvent(222, 6) -- may be wrong id but better than 90
+                end
+            end
+        end
         player:setPos(0, 0, 0, 0, 60)
     end
 end
 
 entity.onInstanceCreated = function(player, target, instance)
-    if (instance) then
+    if instance then
         player:setInstance(instance)
         player:instanceEntry(target, 4)
-
         local party = player:getParty()
-        if (party ~= nil) then
+        if party ~= nil then
             for i, v in pairs(party) do
                 if v:getID() ~= player:getID() and v:getZoneID() == player:getZoneID() then
                     v:setInstance(instance)
-                    v:startEvent(90) -- wrong csid, yet better than nothing
+                    v:instanceEntry(target, 4)
                 end
             end
         end

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1558,12 +1558,13 @@ namespace luautils
         }
 
         auto name = (const char*)PChar->loc.zone->GetName();
+        auto zoneId = (const uint16*)PChar->loc.zone->GetID();
 
         sol::function onRegionLeave;
-        if (PChar->PInstance)
+        if (PChar->PInstance && zoneId == (const uint16*)PChar->PInstance->GetZone()->GetID())
         {
             auto instance_name = (const char*)PChar->PInstance->GetName();
-            onRegionLeave      = lua["tpz"]["zones"][name]["instance"][instance_name]["onRegionLeave"];
+            onRegionLeave = lua["tpz"]["zones"][name]["instance"][instance_name]["onRegionLeave"];
         }
         else
         {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Related to issue #2655 

When the other users were teleported to The Ashu Talif, he wanted to run the onRegionLeave of The black coffin instance in the Arrapago reef area. However, the black coffin is in The Ashu Talif area. This modification allows to say If the player is in the zone of the instance then we execute the onRegionLeave of the zone with the instance otherwise we execute the onRegionLeave of the current zone.

