### PR TITLE
Raycast should find closest point to end-polygon if off-mesh, not start-polygon

### DIFF
--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -470,7 +470,7 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end, bool look
     if (distanceToWall < 0.01f && lookOffMesh)
     {
         // Overwrite epos with closest valid point
-        status = m_navMeshQuery.closestPointOnPolyBoundary(startRef, epos, epos);
+        status = m_navMeshQuery.closestPointOnPolyBoundary(endRef, epos, epos);
 
         if (dtStatusFailed(status))
         {


### PR DESCRIPTION
If the end position is off-mesh, it should look for the closest on-mesh point to it. This should be done on the polygon that is closest to the end position (`endRef`), not the start position (`startRef`).

Currently monsters can aggro through walls if the player is off-mesh (i.e. close to a wall), since it finds a point on the start polygon where the monster itself is.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
